### PR TITLE
DOCSP-13859: UpdateOne usage example

### DIFF
--- a/source/code-snippets/updateOne.go
+++ b/source/code-snippets/updateOne.go
@@ -15,14 +15,13 @@ func main() {
 	// Replace the uri string with your MongoDB deployment's connection string.
 	uri := "mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority"
 
-	ctx := context.TODO()
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
 
 	if err != nil {
 		panic(err)
 	}
 	defer func() {
-		if err = client.Disconnect(ctx); err != nil {
+		if err = client.Disconnect(context.TODO()); err != nil {
 			panic(err)
 		}
 	}()
@@ -33,7 +32,7 @@ func main() {
 	filter := bson.D{{"_id", id}}
 	update := bson.D{{"$set", bson.D{{"avg_rating", 4.4}}}}
 
-	result, err := myCollection.UpdateOne(ctx, filter, update)
+	result, err := myCollection.UpdateOne(context.TODO(), filter, update)
 	// end updateone
 
 	if err != nil {

--- a/source/code-snippets/updateOne.go
+++ b/source/code-snippets/updateOne.go
@@ -10,10 +10,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func main() {
-	// Replace the uri string with your MongoDB deployment's connection string.
-	uri := "mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority"
+// Replace the uri string with your MongoDB deployment's connection string.
+const uri = "mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority"
 
+func main() {
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
 
 	if err != nil {
@@ -38,5 +38,5 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("%v document was updated.\n", result.ModifiedCount)
+	fmt.Printf("Documents updated: %v\n", result.ModifiedCount)
 }

--- a/source/code-snippets/updateOne.go
+++ b/source/code-snippets/updateOne.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	// Replace the uri string with your MongoDB deployment's connection string.
+	uri := "mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority"
+
+	ctx := context.TODO()
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(ctx); err != nil {
+			panic(err)
+		}
+	}()
+
+	myCollection := client.Database("sample_restaurants").Collection("restaurants")
+	id, _ := primitive.ObjectIDFromHex("5eb3d668b31de5d588f42a7a")
+	filter := bson.D{{"_id", id}}
+	update := bson.D{{"$set", bson.D{{"avg_rating", 4.4}}}}
+
+	result, err := myCollection.UpdateOne(ctx, filter, update)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%v document was updated.\n", result.ModifiedCount)
+}

--- a/source/code-snippets/updateOne.go
+++ b/source/code-snippets/updateOne.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -36,7 +35,7 @@ func main() {
 	// end updateone
 
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	fmt.Printf("%v document was updated.\n", result.ModifiedCount)

--- a/source/code-snippets/updateOne.go
+++ b/source/code-snippets/updateOne.go
@@ -27,12 +27,14 @@ func main() {
 		}
 	}()
 
+	// begin updateone
 	myCollection := client.Database("sample_restaurants").Collection("restaurants")
 	id, _ := primitive.ObjectIDFromHex("5eb3d668b31de5d588f42a7a")
 	filter := bson.D{{"_id", id}}
 	update := bson.D{{"$set", bson.D{{"avg_rating", 4.4}}}}
 
 	result, err := myCollection.UpdateOne(ctx, filter, update)
+	// end updateone
 
 	if err != nil {
 		log.Fatal(err)

--- a/source/includes/connect-guide-note.rst
+++ b/source/includes/connect-guide-note.rst
@@ -1,4 +1,6 @@
 .. note::
-    This example connects to an instance of MongoDB using a connection string.
-    To learn more about connecting to your MongoDB instance, see the
-    `connection guide </fundamentals/connection>`_.
+
+   You can use this example to connect to an instance of MongoDB
+   and interact with a database that contains sample data. To learn more about connecting to your MongoDB
+   instance and loading a sample dataset, see the :doc:`Usage Examples
+   guide </usage-examples>`.

--- a/source/includes/connect-guide-note.rst
+++ b/source/includes/connect-guide-note.rst
@@ -1,6 +1,0 @@
-.. note::
-
-   You can use this example to connect to an instance of MongoDB
-   and interact with a database that contains sample data. To learn more about connecting to your MongoDB
-   instance and loading a sample dataset, see the :doc:`Usage Examples
-   guide </usage-examples>`.

--- a/source/includes/run-example-tip.rst
+++ b/source/includes/run-example-tip.rst
@@ -1,0 +1,4 @@
+.. tip::
+
+   Read the :doc:`Usage Examples guide </usage-examples>` to learn how
+   to run this example.

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -7,10 +7,10 @@ Usage Examples
 .. toctree::
 
    /usage-examples/find-operations
+   /usage-examples/update-operations
 
 ..
    /usage-examples/insert-operations
-   /usage-examples/update-operations
    /usage-examples/delete-operations
    /usage-examples/bulkWrite
    /usage-examples/watch

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -21,7 +21,7 @@ by the value of its ``_id`` field and creates a new field in that document calle
    :language: go
    :dedent:
 
-Click here <TODO: github link to file> to see a fully runnable example.
+Click here **<TODO: github link to file>** to see a fully runnable example.
 
 Expected Result
 ---------------
@@ -45,8 +45,8 @@ Additional Information
 ----------------------
 
 For more information on updating documents, specifying query filters, and
-handling potential errors, see our guide on <TODO: change a document
-fundamental page>.
+handling potential errors, see our guide on **<TODO: change a document
+fundamental page>**.
 
 For more information on update operators,
 see the :manual:`MongoDB update operator reference documentation
@@ -55,4 +55,4 @@ see the :manual:`MongoDB update operator reference documentation
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-:go-api:`UpdateOne() <mongo#Collection.UpdateOne>`
+`UpdateOne() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.UpdateOne>`_

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -11,7 +11,7 @@ This example passes a query filter and an update parameter to the
 ``UpdateOne()`` method. The query filter specifies the document to
 match, while the update parameter specifies the change to
 make to the document. The following code example calls the
-``UpdateOne()`` method on a document matched by its ``id`` field from
+``UpdateOne()`` method on a document matched by its ``_id`` field from
 the ``restaurants`` collection to create a new field called
 ``avg_rating`` with a value of 4.4:
 
@@ -38,7 +38,7 @@ this example should produce the following output:
 
 If you execute a :doc:`find
 </fundamentals/crud/read-operations/retrieve/#find>` operation querying
-for the same ``id`` value used in the example, you should see that the
+for the same ``_id`` value used in the example, you should see that the
 matched document now includes the ``avg_rating`` field.
 
 Additional Information

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -4,16 +4,13 @@ Update a Document
 
 .. default-domain:: mongodb
 
-You can update a document in a collection by using the ``Collection.UpdateOne()``
+You can update a document in a collection by using the ``UpdateOne()``
 method. 
 
-This example passes a query filter and an update parameter to the
-``UpdateOne()`` method. The query filter specifies the document to
-match, while the update parameter specifies the change to
-make to the document. The following code example calls the
-``UpdateOne()`` method on a document matched by its ``_id`` field from
-the ``restaurants`` collection to create a new field called
-``avg_rating`` with a value of 4.4:
+The following example passes a query filter and an update parameter to the
+``UpdateOne()`` method, which matches a document in the ``restaurants`` collection
+by the value of its ``_id`` field and creates a new field in that document called
+``avg_rating`` with a value of *4.4*:
 
 .. include:: /includes/run-example-tip.rst
 
@@ -26,19 +23,11 @@ the ``restaurants`` collection to create a new field called
 
 Click here <TODO: github link to file> to see a fully runnable example.
 
-.. note::
-
-   If the query filter does not match any documents, the operation will
-   return a result with a ``MatchedCount`` property of 0. If the filter
-   matches multiple documents, the method will select and update one document.
-
 Expected Result
 ---------------
 
-If you execute a :doc:`find
-</fundamentals/crud/read-operations/retrieve/#find>` operation querying
-for the same ``_id`` value used in the example, you should see that the
-matched document now includes the ``avg_rating`` field:
+After you run the code example, the document will include the
+``avg_rating`` field with the specified value:
 
 .. code-block:: json
    :copyable: false
@@ -56,8 +45,8 @@ Additional Information
 ----------------------
 
 For more information on updating documents, specifying query filters, and
-handling potential errors, see our guide on :doc:`changing a document
-</fundamentals/crud/write-operations/change-a-document/>`.
+handling potential errors, see our guide on <TODO: change a document
+fundamental page>.
 
 For more information on update operators,
 see the :manual:`MongoDB update operator reference documentation
@@ -66,5 +55,4 @@ see the :manual:`MongoDB update operator reference documentation
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-- :go-api:`UpdateOne() <mongo#Collection.UpdateOne>`
-- :go-api:`UpdateResult <mongo#UpdateResult>`
+:go-api:`UpdateOne() <mongo#Collection.UpdateOne>`

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -34,7 +34,12 @@ this example should produce the following output:
 
 .. code-block:: none
     
-   1 documents was updated.
+   1 document was updated.
+
+If you execute a :doc:`find
+</fundamentals/crud/read-operations/retrieve/#find>` operation querying
+for the same ``id`` value used in the example, you should see that the
+matched document now includes the ``avg_rating`` field.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -20,7 +20,7 @@ the ``restaurants`` collection to create a new field called
 .. literalinclude:: /code-snippets/updateOne.go
    :start-after: begin updateone
    :end-before: end updateone
-   :emphasize-lines: 36
+   :emphasize-lines: 6
    :language: go
    :dedent:
 
@@ -30,7 +30,7 @@ the ``restaurants`` collection to create a new field called
    return a result with a ``MatchedCount`` property of 0. If the filter
    matches multiple documents, the method will select and update one document.
 
-Expected Output
+Expected Result
 ---------------
 
 If you execute a :doc:`find
@@ -41,7 +41,7 @@ matched document now includes the ``avg_rating`` field:
 .. code-block:: json
    :copyable: false
 
-   // results truncated
+   // result truncated
    { 
       "_id" : ObjectId("5eb3d668b31de5d588f42a7a"),
       ...

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -24,6 +24,8 @@ the ``restaurants`` collection to create a new field called
    :language: go
    :dedent:
 
+Click here <TODO: github link to file> to see a fully runnable example.
+
 .. note::
 
    If the query filter does not match any documents, the operation will

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -15,10 +15,14 @@ make to the document. The following code example calls the
 the ``restaurants`` collection to create a new field called
 ``avg_rating`` with a value of 4.4:
 
-.. include:: /includes/connect-guide-note.rst
+.. include:: /includes/run-example-tip.rst
 
 .. literalinclude:: /code-snippets/updateOne.go
+   :start-after: begin updateone
+   :end-before: end updateone
+   :emphasize-lines: 36
    :language: go
+   :dedent:
 
 .. note::
 
@@ -29,24 +33,29 @@ the ``restaurants`` collection to create a new field called
 Expected Output
 ---------------
 
-When executed against a MongoDB cluster loaded with the sample data,
-this example should produce the following output:
-
-.. code-block:: none
-    
-   1 document was updated.
-
 If you execute a :doc:`find
 </fundamentals/crud/read-operations/retrieve/#find>` operation querying
 for the same ``_id`` value used in the example, you should see that the
-matched document now includes the ``avg_rating`` field.
+matched document now includes the ``avg_rating`` field:
+
+.. code-block:: json
+   :copyable: false
+
+   // results truncated
+   { 
+      "_id" : ObjectId("5eb3d668b31de5d588f42a7a"),
+      ...
+      "name" : "Green House Cafe",
+      "restaurant_id" : "40372112",
+      "avg_rating" : 4.4
+   }
 
 Additional Information
 ----------------------
 
-For more information on using query filters with the Go Driver,
-see the :doc:`query specification guide
-</fundamentals/crud/query-document/>`.
+For more information on updating documents, specifying query filters, and
+handling potential errors, see our guide on :doc:`changing a document
+</fundamentals/crud/write-operations/change-a-document/>`.
 
 For more information on update operators,
 see the :manual:`MongoDB update operator reference documentation

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -3,3 +3,52 @@ Update a Document
 =================
 
 .. default-domain:: mongodb
+
+You can update a document in a collection by using the ``Collection.UpdateOne()``
+method. 
+
+This example passes a query filter and an update parameter to the
+``UpdateOne()`` method. The query filter specifies the document to
+match, while the update parameter specifies the change to
+make to the document. The following code example calls the
+``UpdateOne()`` method on a document matched by its ``id`` field from
+the ``restaurants`` collection to create a new field called
+``avg_rating`` with a value of 4.4:
+
+.. include:: /includes/connect-guide-note.rst
+
+.. literalinclude:: /code-snippets/updateOne.go
+   :language: go
+
+.. note::
+
+   If the query filter does not match any documents, the operation will
+   return a result with a ``MatchedCount`` property of 0. If the filter
+   matches multiple documents, the method will select and update one document.
+
+Expected Output
+---------------
+
+When executed against a MongoDB cluster loaded with the sample data,
+this example should produce the following output:
+
+.. code-block:: none
+    
+   1 documents was updated.
+
+Additional Information
+----------------------
+
+For more information on using query filters with the Go Driver,
+see the :doc:`query specification guide
+</fundamentals/crud/query-document/>`.
+
+For more information on update operators,
+see the :manual:`MongoDB update operator reference documentation
+</reference/operator/update/#update-operators>`.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+- :go-api:`UpdateOne() <mongo#Collection.UpdateOne>`
+- :go-api:`UpdateResult <mongo#UpdateResult>`


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13859

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13859-update-one-usage-ex/usage-examples/updateOne/

**TODO:** edit links to Fundamentals pages "Change a Document" and "Retrieve Data" when they are created

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
