### PR TITLE
DOCSP-13863 delete many usage example

### DIFF
--- a/source/includes/usage-examples/code-snippets/deleteMany.go
+++ b/source/includes/usage-examples/code-snippets/deleteMany.go
@@ -27,13 +27,13 @@ func main() {
 
 	// begin deleteMany
 	coll := client.Database("sample_mflix").Collection("movies")
-	filter := bson.D{{"runtime": bson.D{"$gt": 800}}}
+	filter := bson.D{{"runtime": bson.D{{"$gt": 800}}}}
 
 	results, err := coll.DeleteMany(context.TODO(), filter)
 	// end deleteMany
 
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	// When you run this file for the first time, it should print "Documents deleted: 4"

--- a/source/includes/usage-examples/code-snippets/deleteMany.go
+++ b/source/includes/usage-examples/code-snippets/deleteMany.go
@@ -27,7 +27,7 @@ func main() {
 
 	// begin deleteMany
 	coll := client.Database("sample_mflix").Collection("movies")
-	filter := bson.M{"runtime": bson.M{"$gt": 800}}
+	filter := bson.D{{"runtime": bson.D{"$gt": 800}}}
 
 	results, err := coll.DeleteMany(context.TODO(), filter)
 	// end deleteMany

--- a/source/includes/usage-examples/code-snippets/deleteMany.go
+++ b/source/includes/usage-examples/code-snippets/deleteMany.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Replace the uri string with your MongoDB deployment's connection string.
+const uri = "mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority"
+
+func main() {
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	// begin deleteMany
+	coll := client.Database("sample_mflix").Collection("movies")
+	filter := bson.M{"runtime": bson.M{"$gt": 800}}
+
+	results, err := coll.DeleteMany(context.TODO(), filter)
+	// end deleteMany
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// When you run this file for the first time, it should print "Documents deleted: 4"
+	fmt.Printf("Documents deleted: %d\n", results.DeletedCount)
+}

--- a/source/includes/usage-examples/code-snippets/deleteMany.go
+++ b/source/includes/usage-examples/code-snippets/deleteMany.go
@@ -27,7 +27,7 @@ func main() {
 
 	// begin deleteMany
 	coll := client.Database("sample_mflix").Collection("movies")
-	filter := bson.D{{"runtime": bson.D{{"$gt": 800}}}}
+	filter := bson.D{{"runtime", bson.D{{"$gt", 800}}}}
 
 	results, err := coll.DeleteMany(context.TODO(), filter)
 	// end deleteMany

--- a/source/includes/usage-examples/code-snippets/deleteMany.go
+++ b/source/includes/usage-examples/code-snippets/deleteMany.go
@@ -14,8 +14,8 @@ import (
 const uri = "mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority"
 
 func main() {
-
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+	
 	if err != nil {
 		panic(err)
 	}

--- a/source/includes/usage-examples/code-snippets/deleteOne.go
+++ b/source/includes/usage-examples/code-snippets/deleteOne.go
@@ -27,7 +27,9 @@ func main() {
 
 	// begin deleteOne
 	coll := client.Database("sample_mflix").Collection("movies")
-	result, err := coll.DeleteOne(context.TODO(), bson.D{{"title", "Twilight"}})
+	filter := bson.D{{"title", "Twilight"}}
+
+	result, err := coll.DeleteOne(context.TODO(), filter)
 	// end deleteOne
 
 	if err != nil {

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -7,9 +7,10 @@ Delete Multiple Documents
 You can delete multiple documents in a collection by using the
 ``DeleteMany()`` method. 
 
-The following example specifies a query filter that matches documents in
-the ``movies`` collection where the ``runtime`` field is greater than
-*800*, and deletes all the matching documents.
+The following example specifies a query filter to the ``DeleteMany()``
+method, which matches documents in the ``movies`` collection where the
+``runtime`` field is greater than *800* and deletes all the matching
+documents. 
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
@@ -32,11 +33,10 @@ the following documents in the ``movies`` collection:
    :copyable: false
 
    // results truncated
-   
-   { "_id":{"$oid":"573a1397f29313caabce69db"}, ... "runtime":1256, ... },
-   { "_id":{"$oid":"573a1397f29313caabce75fe"}, ... "runtime":910, ... },
-   { "_id":{"$oid":"573a1399f29313caabcee1aa"}, ... "runtime":1140, ... },
-   { "_id":{"$oid":"573a13a6f29313caabd18ae0"}, ... "runtime":877, ... }
+   { "_id": ObjectId("573a1397f29313caabce69db"), ... , "runtime": 1256, ... },
+   { "_id": ObjectId("573a1397f29313caabce75fe"), ... , "runtime": 910, ... },
+   { "_id": ObjectId("573a1399f29313caabcee1aa"), ... , "runtime": 1140, ... },
+   { "_id": ObjectId("573a13a6f29313caabd18ae0"), ... , "runtime": 877, ... }
 
 For an example on how to find multiple documents, see our :doc:`Find
 Usage Example </usage-examples/find>`.

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -3,3 +3,49 @@ Delete Multiple Documents
 =========================
 
 .. default-domain:: mongodb
+
+You can delete multiple documents in a collection by using the
+``DeleteMany()`` method. 
+
+The following example specifies a query filter that matches documents in
+the ``movies`` collection where the ``runtime`` field is greater than
+*800*, and deletes all documents that match.
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
+.. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go
+   :start-after: begin deleteMany
+   :end-before: end deleteMany
+   :emphasize-lines: 3
+   :language: go
+   :dedent:
+
+Click here <TODO> to see a fully runnable example.
+
+Expected Result
+---------------
+
+After running the preceding code snippet, you should not be able to find
+the following documents in the ``movies`` collection:
+
+.. code-block:: json
+
+    { "_id":{"$oid":"573a1397f29313caabce69db"}, ... "runtime":1256, ... },
+    { "_id":{"$oid":"573a1397f29313caabce75fe"}, ... "runtime":910, ... },
+    { "_id":{"$oid":"573a1399f29313caabcee1aa"}, ... "runtime":1140, ... },
+    { "_id":{"$oid":"573a13a6f29313caabd18ae0"}, ... "runtime":877, ... }
+
+For an example on how to find multiple documents, see our :doc:`Find
+Usage Example </usage-examples/find>`.
+
+Additional Information
+----------------------
+
+For more information on deleting documents, specifying query filters,
+and handling potential errors, see our guide on <TODO:
+Deleting a Document>.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+`DeleteOne() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.DeleteOne>`__

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -48,4 +48,4 @@ Deleting a Document>.
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-`DeleteOne() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.DeleteOne>`__
+`DeleteMany() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.DeleteMany>`__

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -29,11 +29,14 @@ After running the preceding code snippet, you should not be able to find
 the following documents in the ``movies`` collection:
 
 .. code-block:: json
+   :copyable: false
 
-    { "_id":{"$oid":"573a1397f29313caabce69db"}, ... "runtime":1256, ... },
-    { "_id":{"$oid":"573a1397f29313caabce75fe"}, ... "runtime":910, ... },
-    { "_id":{"$oid":"573a1399f29313caabcee1aa"}, ... "runtime":1140, ... },
-    { "_id":{"$oid":"573a13a6f29313caabd18ae0"}, ... "runtime":877, ... }
+   // results truncated
+   
+   { "_id":{"$oid":"573a1397f29313caabce69db"}, ... "runtime":1256, ... },
+   { "_id":{"$oid":"573a1397f29313caabce75fe"}, ... "runtime":910, ... },
+   { "_id":{"$oid":"573a1399f29313caabcee1aa"}, ... "runtime":1140, ... },
+   { "_id":{"$oid":"573a13a6f29313caabd18ae0"}, ... "runtime":877, ... }
 
 For an example on how to find multiple documents, see our :doc:`Find
 Usage Example </usage-examples/find>`.

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -9,14 +9,14 @@ You can delete multiple documents in a collection by using the
 
 The following example specifies a query filter that matches documents in
 the ``movies`` collection where the ``runtime`` field is greater than
-*800*, and deletes all documents that match.
+*800*, and deletes all the matching documents.
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go
    :start-after: begin deleteMany
    :end-before: end deleteMany
-   :emphasize-lines: 3
+   :emphasize-lines: 4
    :language: go
    :dedent:
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -7,9 +7,10 @@ Delete a Document
 You can delete a document in a collection using the ``DeleteOne()``
 method. 
 
-The following example specifies a query filter that matches documents in
-the ``movies`` collection with the value "Twilight" in the ``title`` field, and
-deletes the first document that matches. 
+The following example specifies a query filter to the ``DeleteOne()``
+method, which matches documents in the ``movies`` collection where the
+``title`` field is "Twilight", and deletes the first document that
+matches. 
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
@@ -32,12 +33,7 @@ the following document in the ``movies`` collection:
    :copyable: false
 
    // result truncated
-   { 
-      "_id": { "$oid": "573a13bff29313caabd5e06b" }, 
-      ...
-      "title": "Twilight",
-      ...
-   }
+   { "_id": ObjectId("573a13bff29313caabd5e06b"), ..., "title": "Twilight", ... }
 
 For an example on how to find a document, see our :doc:`Find
 One Usage Example </usage-examples/findOne>`.

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -16,7 +16,7 @@ deletes the first document that matches.
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteOne.go
    :start-after: begin deleteOne
    :end-before: end deleteOne
-   :emphasize-lines: 2
+   :emphasize-lines: 4
    :language: go
    :dedent:
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -29,12 +29,15 @@ After running the preceding code snippet, you should not be able to find
 the following document in the ``movies`` collection:
 
 .. code-block:: json
+   :copyable: false
 
-    { "_id": { "$oid": "573a13bff29313caabd5e06b" }, 
+   // result truncated
+   { 
+      "_id": { "$oid": "573a13bff29313caabd5e06b" }, 
       ...
       "title": "Twilight",
       ...
-    }
+   }
 
 For an example on how to find a document, see our :doc:`Find
 One Usage Example </usage-examples/findOne>`.

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -52,5 +52,5 @@ see the :manual:`MongoDB query operator reference documentation
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-- `Find() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.Find>`_
-- `Cursor <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Cursor>`_
+- `Find() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.Find>`__
+- `Cursor <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Cursor>`__


### PR DESCRIPTION
## Pull Request Info
Page: Usage Examples > Delete Operations > Delete Many Documents

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13863

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13863-DeleteManyUsageExample/usage-examples/deleteMany/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
