### PR TITLE
DOCSP-13858: add insertMany usage example

### DIFF
--- a/source/includes/usage-examples/code-snippets/insertMany.go
+++ b/source/includes/usage-examples/code-snippets/insertMany.go
@@ -43,7 +43,7 @@ func main() {
 		panic(err)
 	}
 
-	// When you run this file it should print "Two documents inserted with Ids: ...
+	// When you run this file it should print "2 documents inserted with IDs: ...
 	fmt.Printf("%d documents inserted with IDs:\n", len(result.InsertedIDs))
 	for _, id := range result.InsertedIDs {
 		fmt.Printf("\t%s\n", id)

--- a/source/includes/usage-examples/code-snippets/insertMany.go
+++ b/source/includes/usage-examples/code-snippets/insertMany.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+
+	var uri string
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
+		log.Fatal("You must set your `MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	// begin insertMany
+	coll := client.Database("insertDB").Collection("haikus")
+	docs := []interface{}{
+		bson.D{{"title", "Record of a Shriveled Datum"}, {"text", "No bytes, no problem. Just insert a document, in MongoDB"}},
+		bson.D{{"title", "Showcasing a Blossoming Binary"}, {"text", "Binary data, safely stored with GridFS. Bucket the data"}},
+	}
+
+	result, err := coll.InsertMany(context.TODO(), docs)
+	// end insertMany
+
+	if err != nil {
+		panic(err)
+	}
+
+	// When you run this file it should print "Two documents inserted with Ids: ...
+	fmt.Printf("%d documents inserted with IDs:\n", len(result.InsertedIDs))
+	for _, id := range result.InsertedIDs {
+		fmt.Printf("\t%s\n", id)
+	}
+}

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -1,5 +1,59 @@
-=========================
-Insert Multiple Documents
-=========================
+========================
+Insert Multiple Document
+========================
 
 .. default-domain:: mongodb
+
+You can insert multiple documents into a collection by using the ``InsertMany()``
+method.
+
+The following example creates a two new document containing a ``title`` and ``text``
+field and inserts it into the ``haikus`` collection of the ``insertDB`` database:
+
+.. note:: Non-existent Database and Collections
+
+    The driver automatically creates the necessary database and/or collection
+    when you perform a write operation against them if they don't already exist.
+
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
+.. literalinclude:: /includes/usage-examples/code-snippets/insertMany.go
+   :start-after: begin insertMany
+   :end-before: end insertMany
+   :emphasize-lines: 4
+   :language: go
+   :dedent:
+
+Click `here <{+example+}/insertMany.go>`__ to see a fully runnable example.
+
+Expected Result
+---------------
+
+After you run the code example, a two new documents will be present in the
+collection with an ``_id`` field that matches the previous output:
+
+.. code-block:: json
+   :copyable: false
+
+   {
+     "_id": ObjectId("..."),
+     "title": "Record of a Shriveled Datum",
+     "text": "No bytes, no problem. Inserting a document. In MongoDB"
+   },
+   {
+     "_id": ObjectId("..."),
+     "title": "Showcasing a Blossoming Binary",
+     "text": "Binary data, safely stored with GridFS. Bucket the data"
+   }
+
+Additional Information
+----------------------
+
+For more information on inserting documents, see our guide on
+**<TODO: inserting documents fundamental page>**.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+`InsertMany() <{+godocs+}/mongo#Collection.InsertMany>`__

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -1,6 +1,6 @@
-========================
-Insert Multiple Document
-========================
+=========================
+Insert Multiple Documents
+=========================
 
 .. default-domain:: mongodb
 
@@ -30,7 +30,7 @@ Click `here <{+example+}/insertMany.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the code example, a two new documents will be present in the
+After you run the code example, two new documents will be present in the
 collection with an ``_id`` field that matches the previous output:
 
 .. code-block:: json

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -21,7 +21,7 @@ field and inserts it into the ``haikus`` collection of the ``insertDB`` database
 .. literalinclude:: /includes/usage-examples/code-snippets/insertMany.go
    :start-after: begin insertMany
    :end-before: end insertMany
-   :emphasize-lines: 4
+   :emphasize-lines: 7
    :language: go
    :dedent:
 

--- a/source/usage-examples/update-operations.txt
+++ b/source/usage-examples/update-operations.txt
@@ -5,6 +5,7 @@ Write Operations
 .. default-domain:: mongodb
 
 - :doc:`Insert a Document </usage-examples/insertOne>`
+- :doc:`Insert Multiple Documents </usage-examples/insertMany>`
 - :doc:`Update a Document </usage-examples/updateOne>`
 - :doc:`Update Multiple Documents </usage-examples/updateMany>`
 - :doc:`Replace a Document </usage-examples/replaceOne>`
@@ -13,6 +14,7 @@ Write Operations
    :caption: Examples
 
    /usage-examples/insertOne
+   /usage-examples/insertMany
    /usage-examples/updateOne
    /usage-examples/updateMany
    /usage-examples/replaceOne


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13858

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13858/usage-examples/insertMany/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?
  - GH link won't work until merged into master
- [x] Are the staging links in the PR description updated?
