### PR TITLE
DOCSP-13854 usage examples landing page

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -3,7 +3,7 @@ title = "Go"
 toc_landing_pages = [
     "/fundamentals/connection",
     "/fundamentals/crud",
-    "/fundamentals/builders"
+    "/usage-examples"
 ]
 
 [constants]

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -51,12 +51,12 @@ example into your development environment of choice. You can follow the
 started with the MongoDB Go Driver. 
 
 Once you've copied a usage example, you'll need to edit and place your
-connection string in your environment variables to get the example
+connection string in your environment variable to get the example
 connected to your instance of MongoDB. 
 
 .. code-block:: go
    
-   os.Getenv("MONGODB_URI")
+   uri := os.Getenv("MONGODB_URI")
 
 Environment Variable
 ~~~~~~~~~~~~~~~~~~~~
@@ -64,17 +64,17 @@ Environment Variable
 You can use `GoDotEnv <https://github.com/joho/godotenv>`__ to set up
 your environment variable. 
 
-In your ``.env`` file at the root of your project, assure you have the
-following:
+In your ``.env`` file at the root of your project, add the following
+application configuration: 
+
+.. code-block::
+
+   MONGODB_URI=mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority
 
 .. note::
 
    Replace the following with your MongoDB deployment's connection string.
 
-.. code-block::
-
-   MONGODB_URI=mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority
-   
 Connection String
 ~~~~~~~~~~~~~~~~~
 

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -62,7 +62,7 @@ an environment variable <usage-examples-env-variable>` with
 Environment Variable
 ~~~~~~~~~~~~~~~~~~~~
 
-You can use `GoDotEnv <https://github.com/joho/godotenv>`__ to set up
+You can use `GoDotEnv <https://github.com/joho/godotenv>`__ to define
 your environment variable. 
 
 Add the following application configuration in your ``.env`` file at the
@@ -75,7 +75,7 @@ root of your project. For more information, see the
 
 .. note::
 
-   Replace the preceding with your MongoDB deployment's connection string.
+   Replace the preceding connection string with :ref:`your MongoDB deployment's connection string <usage-examples-connection-string>`.
 
 .. _usage-examples-connection-string:
 
@@ -83,13 +83,13 @@ Connection String
 ~~~~~~~~~~~~~~~~~
 
 You can use the :guides:`Atlas Connectivity Guide </cloud/connectionstring/>`
-to enable connectivity to your instance of Atlas and find the
-:manual:`connection string </reference/connection-string/>` to set the
-``MONGODB_URI`` environment variable in the usage example. If your instance uses
-:manual:`SCRAM authentication </core/security-scram/>`, you can replace
-``<user>`` with your username, ``<password>`` with your password, and
-``<cluster-url>`` with the IP address or URL of your instance.
+to enable connectivity to your Atlas instance and find the
+:manual:`connection string </reference/connection-string/>` to define your
+``MONGODB_URI`` environment variable to run our usage examples. If your
+instance uses :manual:`SCRAM authentication </core/security-scram/>`,
+you can replace ``<user>`` with your username, ``<password>`` with your
+password, and ``<cluster-url>`` with the IP address or URL of your instance. 
 
-For more information about connecting to your MongoDB instance, see the
+For more information about connecting to your MongoDB instance, see our
 <TODO: Connection Guide>.
 

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -4,6 +4,12 @@ Usage Examples
 
 .. default-domain:: mongodb
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
 .. toctree::
 
    /usage-examples/find-operations
@@ -23,16 +29,10 @@ Overview
 --------
 
 Usage examples provide convenient starting points for popular MongoDB
-operations. Each example provides:
+operations. Each example provides the following:
 
-- an explanation of the operation in the example showing the
-  purpose and a sample use case for the method
-
-- an explanation of how to use the operation, including parameters,
-  return values, and common exceptions you might encounter
-
-- a full Go program that you can copy and paste to run the example
-  in your own environment
+- A full Go program that to run in your own environment
+- The expected result after running the program
 
 How to Use the Usage Examples
 -----------------------------
@@ -48,22 +48,44 @@ or you can
 Once you have imported the dataset, you can copy and paste a usage
 example into your development environment of choice. You can follow the
 :doc:`quick start guide </quick-start>` to learn more about getting
-started with the MongoDB Go Driver. Once you've copied a usage example,
-you'll need to edit the connection string to get the example connected to
-your instance of MongoDB:
+started with the MongoDB Go Driver. 
+
+Once you've copied a usage example, you'll need to edit and place your
+connection string in your environment variables to get the example
+connected to your instance of MongoDB. 
 
 .. code-block:: go
+   
+   os.Getenv("MONGODB_URI")
 
-   // Replace the following with your MongoDB deployment's connection string.
-   uri := "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+Environment Variable
+~~~~~~~~~~~~~~~~~~~~
+
+You can use `GoDotEnv <https://github.com/joho/godotenv>`__ to set up
+your environment variable. 
+
+In your ``.env`` file at the root of your project, assure you have the
+following:
+
+.. note::
+
+   Replace the following with your MongoDB deployment's connection string.
+
+.. code-block::
+
+   MONGODB_URI=mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority
+   
+Connection String
+~~~~~~~~~~~~~~~~~
 
 You can use the :guides:`Atlas Connectivity Guide </cloud/connectionstring/>`
 to enable connectivity to your instance of Atlas and find the
-:manual:`connection string </reference/connection-string/>` to replace the
-``uri`` variable in the usage example. If your instance uses
+:manual:`connection string </reference/connection-string/>` to set the
+``MONGODB_URI`` environment variable in the usage example. If your instance uses
 :manual:`SCRAM authentication </core/security-scram/>`, you can replace
 ``<user>`` with your username, ``<password>`` with your password, and
 ``<cluster-url>`` with the IP address or URL of your instance.
 
 For more information about connecting to your MongoDB instance, see the
-Connection Guide.
+<TODO: Connection Guide>.
+

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -31,7 +31,7 @@ Overview
 Usage examples provide convenient starting points for popular MongoDB
 operations. Each example provides the following:
 
-- A full Go program that to run in your own environment
+- A full Go program that you can run in your own environment
 - The expected result after running the program
 
 How to Use the Usage Examples
@@ -39,21 +39,19 @@ How to Use the Usage Examples
 
 These examples use the :atlas:`sample datasets <sample-data>` provided by
 Atlas. You can load them into your database on the free tier of MongoDB
-Atlas by following the
-:atlas:`Get Started with Atlas Guide <getting-started/#atlas-getting-started>`
-or you can
+Atlas by following the :atlas:`Get Started with Atlas Guide
+<getting-started/#atlas-getting-started>` or you can
 :guides:`import the sample dataset into a local MongoDB instance
 </server/import/>`.
 
-Once you have imported the dataset, you can copy and paste a usage
+Once you import the dataset, you can copy and paste a usage
 example into your development environment of choice. You can follow the
 :doc:`quick start guide </quick-start>` to learn more about getting
 started with the MongoDB Go Driver. 
 
-Once you've copied a usage example, you'll need to edit and place
-:ref:`your connection string <usage-examples-connection-string>` in
-:ref:`your environment variable <usage-examples-env-variable>` to get
-the example connected to your instance of MongoDB. 
+To connect the example to your MongoDB instance, you must :ref:`define
+an environment variable <usage-examples-env-variable>` with
+:ref:`your connection string <usage-examples-connection-string>`. 
 
 .. code-block:: go
    
@@ -67,8 +65,9 @@ Environment Variable
 You can use `GoDotEnv <https://github.com/joho/godotenv>`__ to set up
 your environment variable. 
 
-When you get to the "Usage" section, add the following application
-configuration in your ``.env`` file at the root of your project: 
+Add the following application configuration in your ``.env`` file at the
+root of your project. For more information, see the
+`GoDotEnv documentation <https://github.com/joho/godotenv#usage>`__.
 
 .. code-block::
 
@@ -76,7 +75,7 @@ configuration in your ``.env`` file at the root of your project:
 
 .. note::
 
-   Replace the following with your MongoDB deployment's connection string.
+   Replace the preceding with your MongoDB deployment's connection string.
 
 .. _usage-examples-connection-string:
 

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -50,13 +50,16 @@ example into your development environment of choice. You can follow the
 :doc:`quick start guide </quick-start>` to learn more about getting
 started with the MongoDB Go Driver. 
 
-Once you've copied a usage example, you'll need to edit and place your
-connection string in your environment variable to get the example
-connected to your instance of MongoDB. 
+Once you've copied a usage example, you'll need to edit and place
+:ref:`your connection string <usage-examples-connection-string>` in
+:ref:`your environment variable <usage-examples-env-variable>` to get
+the example connected to your instance of MongoDB. 
 
 .. code-block:: go
    
    uri := os.Getenv("MONGODB_URI")
+
+.. _usage-examples-env-variable:
 
 Environment Variable
 ~~~~~~~~~~~~~~~~~~~~
@@ -64,8 +67,8 @@ Environment Variable
 You can use `GoDotEnv <https://github.com/joho/godotenv>`__ to set up
 your environment variable. 
 
-In your ``.env`` file at the root of your project, add the following
-application configuration: 
+When you get to the "Usage" section, add the following application
+configuration in your ``.env`` file at the root of your project: 
 
 .. code-block::
 
@@ -74,6 +77,8 @@ application configuration:
 .. note::
 
    Replace the following with your MongoDB deployment's connection string.
+
+.. _usage-examples-connection-string:
 
 Connection String
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Added Usage Examples landing page.
This page differs from the the Node and Java driver since we're incorporating environment variables.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13854

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13854-UsageExamplesLanding/usage-examples/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
