### PR TITLE
DOCSP-13861 replace usage example

### DIFF
--- a/source/includes/usage-examples/code-snippets/replace.go
+++ b/source/includes/usage-examples/code-snippets/replace.go
@@ -29,9 +29,9 @@ func main() {
 	}()
 
 	// begin replace
-	coll := client.Database("sample_mflix").Collection("movies")
-	filter := bson.D{{"title", "Shrek"}}
-	replacement := bson.D{{"title", "Shrek"}, {"plot", "After his swamp is filled with magical creatures, an ogre agrees to rescue a princess for a villainous lord in order to get his land back."}}
+	coll := client.Database("insertDB").Collection("haikus")
+	filter := bson.D{{"title", "Record of a Shriveled Datum"}}
+	replacement := bson.D{{"title", "Dodging Greys"}, {"text", "You can use upsert. No longer need to panic, when there're no matches."}}
 
 	result, err := coll.ReplaceOne(context.TODO(), filter, replacement)
 	// end replace
@@ -40,10 +40,10 @@ func main() {
 		panic(err)
 	}
 
-	// When you run this file for the first time, it should print: "Matched and replaced an existing document."
+	// When you run this file for the first time, it should print: "Number of documents replaced: 1"
 
 	if result.MatchedCount != 0 {
-		fmt.Println("Matched and replaced an existing document.")
+		fmt.Println("Number of documents replaced: %d\n", result.ModifiedCount)
 		return
 	}
 }

--- a/source/includes/usage-examples/code-snippets/replace.go
+++ b/source/includes/usage-examples/code-snippets/replace.go
@@ -41,9 +41,7 @@ func main() {
 	}
 
 	// When you run this file for the first time, it should print: "Number of documents replaced: 1"
-
 	if result.MatchedCount != 0 {
 		fmt.Println("Number of documents replaced: %d\n", result.ModifiedCount)
-		return
 	}
 }

--- a/source/includes/usage-examples/code-snippets/replace.go
+++ b/source/includes/usage-examples/code-snippets/replace.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+
+	var uri string
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
+		log.Fatal("You must set your `MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	// begin replace
+	coll := client.Database("sample_mflix").Collection("movies")
+	filter := bson.D{{"title", "Shrek"}}
+	replacement := bson.D{{"title", "Shrek"}, {"plot", "After his swamp is filled with magical creatures, an ogre agrees to rescue a princess for a villainous lord in order to get his land back."}}
+
+	result, err := coll.ReplaceOne(context.TODO(), filter, replacement)
+	// end replace
+
+	if err != nil {
+		panic(err)
+	}
+
+	// When you run this file for the first time, it should print: "Matched and replaced an existing document."
+
+	if result.MatchedCount != 0 {
+		fmt.Println("Matched and replaced an existing document.")
+		return
+	}
+}

--- a/source/includes/usage-examples/code-snippets/replace.go
+++ b/source/includes/usage-examples/code-snippets/replace.go
@@ -31,7 +31,7 @@ func main() {
 	// begin replace
 	coll := client.Database("insertDB").Collection("haikus")
 	filter := bson.D{{"title", "Record of a Shriveled Datum"}}
-	replacement := bson.D{{"title", "Dodging Greys"}, {"text", "You can use upsert. No longer need to panic, when there're no matches."}}
+	replacement := bson.D{{"title", "Dodging Greys"}, {"text", "When there're no matches, no longer need to panic. You can use upsert"}}
 
 	result, err := coll.ReplaceOne(context.TODO(), filter, replacement)
 	// end replace

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -7,11 +7,11 @@ Replace a Document
 You can replace a document in a collection by using the ``ReplaceOne()``
 method. 
 
-The following example specifies the following to the ``ReplaceOne()``
-method: 
-
-- A query filter matches documents in the ``movies`` collection where the ``title`` field is "Shrek" and replaces the first document that matches with the replacement document. 
-- A replacement document contains a ``title``and ``plot`` field about the movie.
+The following example specifies a query filter and replacement document
+to the ``ReplaceOne()`` method, which matches a document in the
+``movies`` collection where the ``title`` field is "Shrek" and replaces
+it with a document that contains a ``title`` and ``plot`` field about
+the movie: 
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
@@ -38,6 +38,9 @@ replacement document in the ``movies`` collection:
       "title" : "Shrek",
       "plot" : "After his swamp is filled with magical creatures, an ogre agrees to rescue a princess for a villainous lord in order to get his land back."
    }
+
+For an example on how to find a document, see our :doc:`Find
+One Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -3,3 +3,51 @@ Replace a Document
 ==================
 
 .. default-domain:: mongodb
+
+You can replace a document in a collection by using the ``ReplaceOne()``
+method. 
+
+The following example specifies a query filter and a replacement
+document to the ``ReplaceOne()`` method. The query filter matches
+documents in the ``movies`` collection where the ``title`` field is
+"Shrek" and replaces the first document that matches with the
+replacement document. The replacement document only contains a ``title``
+and ``plot`` field about the movie.
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
+.. literalinclude:: /includes/usage-examples/code-snippets/replace.go
+   :start-after: begin replace
+   :end-before: end replace
+   :emphasize-lines: 3, 5
+   :language: go
+   :dedent:
+
+Click `here <{+example+}/replace.go>`__  to see a fully runnable example.
+
+Expected Result
+---------------
+
+After you run the preceding code snippet, MongoDB replaces the existing
+document with the replacement document:
+
+.. code-block:: json
+   :copyable: false
+
+   { 
+      "_id" : ObjectId("573a139af29313caabcf224e"),
+      "title" : "Shrek",
+      "plot" : "After his swamp is filled with magical creatures, an ogre agrees to rescue a princess for a villainous lord in order to get his land back."
+   }
+
+Additional Information
+----------------------
+
+For more information on replacing documents, specifying query filters, and
+handling potential errors, see our guide on **<TODO: change a document
+fundamental page>**.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+`ReplaceOne() <{+godocs+}/mongo#Collection.ReplaceOne>`__

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -36,7 +36,7 @@ replacement document in the ``haikus`` collection:
    { 
       "_id" : ObjectId("..."),
       "title" : "Dodging Greys",
-      "text" : "You can use upsert. No longer need to panic, when there're no matches.."
+      "text" : "When there're no matches, no longer need to panic. You can use upsert."
    }
 
 For an example on how to find a document, see our :doc:`Find

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -7,19 +7,18 @@ Replace a Document
 You can replace a document in a collection by using the ``ReplaceOne()``
 method. 
 
-The following example specifies a query filter and a replacement
-document to the ``ReplaceOne()`` method. The query filter matches
-documents in the ``movies`` collection where the ``title`` field is
-"Shrek" and replaces the first document that matches with the
-replacement document. The replacement document only contains a ``title``
-and ``plot`` field about the movie.
+The following example specifies the following to the ``ReplaceOne()``
+method: 
+
+- A query filter matches documents in the ``movies`` collection where the ``title`` field is "Shrek" and replaces the first document that matches with the replacement document. 
+- A replacement document contains a ``title``and ``plot`` field about the movie.
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/replace.go
    :start-after: begin replace
    :end-before: end replace
-   :emphasize-lines: 3, 5
+   :emphasize-lines: 5
    :language: go
    :dedent:
 
@@ -28,8 +27,8 @@ Click `here <{+example+}/replace.go>`__  to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding code snippet, MongoDB replaces the existing
-document with the replacement document:
+After you run the preceding code snippet, you should be able to find the
+replacement document in the ``movies`` collection: 
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -9,9 +9,9 @@ method.
 
 The following example specifies a query filter and replacement document
 to the ``ReplaceOne()`` method, which matches a document in the
-``movies`` collection where the ``title`` field is "Shrek" and replaces
-it with a document that contains a ``title`` and ``plot`` field about
-the movie: 
+``haikus`` collection where the ``title`` field is "Record of a
+Shriveled Datum" and replaces it with a document that contains a
+``title`` and ``text`` field about a haiku: 
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
@@ -28,15 +28,15 @@ Expected Result
 ---------------
 
 After you run the preceding code snippet, you should be able to find the
-replacement document in the ``movies`` collection: 
+replacement document in the ``haikus`` collection: 
 
 .. code-block:: json
    :copyable: false
 
    { 
-      "_id" : ObjectId("573a139af29313caabcf224e"),
-      "title" : "Shrek",
-      "plot" : "After his swamp is filled with magical creatures, an ogre agrees to rescue a princess for a villainous lord in order to get his land back."
+      "_id" : ObjectId("..."),
+      "title" : "Dodging Greys",
+      "text" : "You can use upsert. No longer need to panic, when there're no matches.."
    }
 
 For an example on how to find a document, see our :doc:`Find


### PR DESCRIPTION
## Pull Request Info

Added Usage Examples > Write Operations > Replace a Document page

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13861

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13861-ReplaceUsageExample/usage-examples/replaceOne/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?
