### PR TITLE
Link to guide

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -10,6 +10,8 @@ Connection Guide
    :depth: 2
    :class: singlecol
 
+.. _golang_connection_guide:
+
 This guide shows you how to connect to a MongoDB instance or replica set
 deployment using the Go Driver.
 
@@ -125,7 +127,7 @@ Connection Options
 
 This section explains several common MongoDB connection and authentication
 options. You can pass the connection options as parameters of the connection
-URI to specify the behavior of the client. 
+URI to specify the behavior of the client.
 
 .. list-table::
    :header-rows: 1

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -91,5 +91,5 @@ you can replace ``<user>`` with your username, ``<password>`` with your
 password, and ``<cluster-url>`` with the IP address or URL of your instance.
 
 For more information about connecting to your MongoDB instance, see our
-<TODO: Connection Guide>.
+:ref:`Connection Guide <golang_connection_guide>`.
 


### PR DESCRIPTION
## Pull Request Info

This adds a ref target in the conneciton guide and links to it from the usage-example overview, replacing the todo.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18438

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=612fd3ad7dcf012930c40704

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18438/usage-examples/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
