### PR TITLE
DOCSP-18444 example section

### DIFF
--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -16,7 +16,7 @@ The following example performs the following in order on the ``haikus``
 collection:
 
 - Matches a document in which the ``title`` is "Record of a Shriveled Datum" and replace it with a new document
-- Matches a document in which the ``title`` is "Dodging Greys" and update that field to "Dodge The Greys"
+- Matches a document in which the ``title`` is "Dodging Greys" and updates that value to "Dodge The Greys"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/bulk.go
    :start-after: begin bulk

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -12,8 +12,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a slice of ``WriteModels`` and an option
-to the ``BulkWrite()`` method, which performs the following in order:
+The following example performs the following in order on the ``haikus``
+collection:
 
 - Match a document where the ``title`` is "Record of a Shriveled Datum" and replace it with a new document
 - Match a document where the ``title`` is "Dodging Greys" and update that field to "Dodge The Greys"

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -7,13 +7,16 @@ Perform Bulk Operations
 You can perform bulk write operations on a collection by using the
 ``BulkWrite()`` method.
 
-The following example specifies a slice of ``WriteModels`` and an option
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example passes a slice of ``WriteModels`` and an option
 to the ``BulkWrite()`` method, which performs the following in order:
 
 - Match a document where the ``title`` is "Record of a Shriveled Datum" and replace it with a new document
 - Match a document where the ``title`` is "Dodging Greys" and update that field to "Dodge The Greys"
-
-.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/bulk.go
    :start-after: begin bulk

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following in order on the ``haikus``
 collection:
 
-- Match a document where the ``title`` is "Record of a Shriveled Datum" and replace it with a new document
-- Match a document where the ``title`` is "Dodging Greys" and update that field to "Dodge The Greys"
+- Matches a document in which the ``title`` is "Record of a Shriveled Datum" and replace it with a new document
+- Matches a document in which the ``title`` is "Dodging Greys" and update that field to "Dodge The Greys"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/bulk.go
    :start-after: begin bulk

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -12,9 +12,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a document containing the ``"dbStats"``
-command to the ``RunCommand()`` method, which retrieves statistics
-about the ``sample_restaurants`` database:
+The following example retrieves statistics about the
+``sample_restaurants`` database: 
 
 .. literalinclude:: /includes/usage-examples/code-snippets/command.go
    :start-after: begin runCommand

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -7,11 +7,14 @@ Run a Command
 You can run commands directly on your MongoDB server by using the
 ``RunCommand()`` method.
 
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
 The following example passes a document containing the ``"dbStats"``
 command to the ``RunCommand()`` method, which retrieves statistics
 about the ``sample_restaurants`` database:
-
-.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/command.go
    :start-after: begin runCommand

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -14,11 +14,11 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example uses the ``EstimatedDocumentCount()`` method to
-count the number of documents in the ``movies`` collection. Then, the
-example passes a query filter to the ``CountDocuments()`` method, which
-counts the number of documents in the ``movies`` collection where the
-``countries`` field contains "China".
+The following example performs the following on the ``movies``
+collection:
+
+- Approximately count the number of documents in the collection
+- Count the number of documents where the ``countries`` field contains "China"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/count.go
    :start-after: begin countDocuments

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -17,8 +17,8 @@ Example
 The following example performs the following on the ``movies``
 collection:
 
-- Approximately count the number of documents in the collection
-- Count the number of documents where the ``countries`` field contains "China"
+- Approzimates the number of documents in the collection
+- Counts the number of documents in which the ``countries`` field contains "China"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/count.go
    :start-after: begin countDocuments

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -17,7 +17,7 @@ Example
 The following example performs the following on the ``movies``
 collection:
 
-- Approzimates the number of documents in the collection
+- Approximates the number of documents in the collection
 - Counts the number of documents in which the ``countries`` field contains "China"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/count.go

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -18,7 +18,7 @@ The following example performs the following on the ``movies``
 collection:
 
 - Approximates the number of documents in the collection
-- Counts the number of documents in which the ``countries`` field contains "China"
+- Counts the number of documents in which the ``countries`` contains "China"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/count.go
    :start-after: begin countDocuments

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -9,13 +9,16 @@ collection by using the ``EstimatedDocumentCount()`` method and an exact
 number of documents in a collection by using the ``CountDocuments()``
 method.
 
-The following example uses the ``EstimatedDocumentCount()`` method to
-count the number of documents in the ``movies`` collection. Then, the
-example uses the ``CountDocuments()`` method to count the number of
-documents in the ``movies`` collection where the ``countries`` field
-contains "China".
+Example
+-------
 
 .. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example uses the ``EstimatedDocumentCount()`` method to
+count the number of documents in the ``movies`` collection. Then, the
+example passes a query filter to the ``CountDocuments()`` method, which
+counts the number of documents in the ``movies`` collection where the
+``countries`` field contains "China".
 
 .. literalinclude:: /includes/usage-examples/code-snippets/count.go
    :start-after: begin countDocuments

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -14,7 +14,7 @@ Example
 
 The following example matches documents in the ``movies`` collection
 where the ``runtime`` field is greater than 800, deleting all 
-documents that matched:
+documents matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go
    :start-after: begin deleteMany

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -12,10 +12,9 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter to the ``DeleteMany()``
-method, which matches documents in the ``movies`` collection where the
-``runtime`` field is greater than 800 and deletes all the matching
-documents:
+The following example matches documents in the ``movies`` collection
+where the ``runtime`` field is greater than 800, deleting all 
+documents that matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go
    :start-after: begin deleteMany

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``movies`` collection
-in which the ``runtime`` field is greater than 800 min, deleting all 
+in which the ``runtime`` is greater than 800 minutes, deleting all 
 documents matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``movies`` collection
-where the ``runtime`` field is greater than 800, deleting all 
+in which the ``runtime`` field is greater than 800 min, deleting all 
 documents matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -7,12 +7,15 @@ Delete Multiple Documents
 You can delete multiple documents in a collection by using the
 ``DeleteMany()`` method. 
 
-The following example specifies a query filter to the ``DeleteMany()``
-method, which matches documents in the ``movies`` collection where the
-``runtime`` field is greater than *800* and deletes all the matching
-documents. 
+Example
+-------
 
 .. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example passes a query filter to the ``DeleteMany()``
+method, which matches documents in the ``movies`` collection where the
+``runtime`` field is greater than 800 and deletes all the matching
+documents:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go
    :start-after: begin deleteMany

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``movies`` collection
-where the ``title`` field is "Twilight", deleting the first document
+in which the ``title`` field is "Twilight", deleting the first document
 matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteOne.go

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``movies`` collection
-in which the ``title`` field is "Twilight", deleting the first document
+in which the ``title`` is "Twilight", deleting the first document
 matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteOne.go

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -12,10 +12,9 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter to the ``DeleteOne()``
-method, which matches documents in the ``movies`` collection where the
-``title`` field is "Twilight", and deletes the first document that
-matches:
+The following example matches documents in the ``movies`` collection
+where the ``title`` field is "Twilight", deleting the first document
+matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteOne.go
    :start-after: begin deleteOne

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -7,12 +7,15 @@ Delete a Document
 You can delete a document in a collection by using the ``DeleteOne()``
 method. 
 
-The following example specifies a query filter to the ``DeleteOne()``
-method, which matches documents in the ``movies`` collection where the
-``title`` field is "Twilight", and deletes the first document that
-matches. 
+Example
+-------
 
 .. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example passes a query filter to the ``DeleteOne()``
+method, which matches documents in the ``movies`` collection where the
+``title`` field is "Twilight", and deletes the first document that
+matches:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteOne.go
    :start-after: begin deleteOne

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -7,12 +7,15 @@ Retrieve Distinct Values of a Field
 You can retrieve a list of distinct values for a field across a
 collection by using the ``Distinct()`` method.
 
-The following example specifies a query filter and a field name to the
-``Distinct()`` method, which matches documents in the ``movies``
-collection where the ``directors`` field contains "Natalie Portman" and
-returns distinct values of the ``title`` field from the matched documents.
+Example
+-------
 
 .. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example passes a query filter and a field name to the
+``Distinct()`` method, which matches documents in the ``movies``
+collection where the ``directors`` field contains "Natalie Portman" and
+returns distinct values of the ``title`` field from the matched documents:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/distinct.go
    :start-after: begin distinct

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -12,10 +12,11 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter and a field name to the
-``Distinct()`` method, which matches documents in the ``movies``
-collection where the ``directors`` field contains "Natalie Portman" and
-returns distinct values of the ``title`` field from the matched documents:
+The following example performs the following on the ``movies``
+collection:
+
+- Match documents where the ``directors`` field contains "Natalie Portman" 
+- Return distinct values of the ``title`` field from the matched documents
 
 .. literalinclude:: /includes/usage-examples/code-snippets/distinct.go
    :start-after: begin distinct

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following on the ``movies``
 collection:
 
-- Matches documents in which the ``directors`` field contains "Natalie Portman" 
-- Returns distinct values of the ``title`` field from the matched documents
+- Matches documents in which the ``directors`` contains "Natalie Portman" 
+- Returns distinct values of the ``title`` from the matched documents
 
 .. literalinclude:: /includes/usage-examples/code-snippets/distinct.go
    :start-after: begin distinct

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following on the ``movies``
 collection:
 
-- Match documents where the ``directors`` field contains "Natalie Portman" 
-- Return distinct values of the ``title`` field from the matched documents
+- Matches documents in which the ``directors`` field contains "Natalie Portman" 
+- Returns distinct values of the ``title`` field from the matched documents
 
 .. literalinclude:: /includes/usage-examples/code-snippets/distinct.go
    :start-after: begin distinct

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``zips`` collection
-in which the ``pop`` field is less than or equal to 500 people,
+in which the ``pop`` is less than or equal to 500 people,
 returning all documents matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/find.go

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -13,7 +13,8 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``zips`` collection
-where the ``pop`` field is less than or equal to 500:
+where the ``pop`` field is less than or equal to 500, returning all
+documents matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/find.go
    :start-after: begin find

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -12,9 +12,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter to the ``Find()`` method,
-which matches documents in the ``zips`` collection where the value of the
-``pop`` field is less than or equal to 500:
+The following example matches documents in the ``zips`` collection
+where the ``pop`` field is less than or equal to 500:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/find.go
    :start-after: begin find

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -7,11 +7,14 @@ Find Multiple Documents
 You can find multiple documents in a collection by using the ``Find()``
 method.
 
-The following example passes a query filter to the ``Find()`` method,
-which matches documents in the ``zips`` collection where the value of the
-``pop`` field is less than or equal to *500*:
+Example
+-------
 
 .. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example passes a query filter to the ``Find()`` method,
+which matches documents in the ``zips`` collection where the value of the
+``pop`` field is less than or equal to 500:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/find.go
    :start-after: begin find

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -13,8 +13,8 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``zips`` collection
-where the ``pop`` field is less than or equal to 500, returning all
-documents matched:
+in which the ``pop`` field is less than or equal to 500 people,
+returning all documents matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/find.go
    :start-after: begin find

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``movies`` collection
-in which the ``title`` field is "The Room", returning the first document 
+in which the ``title`` is "The Room", returning the first document 
 matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -7,11 +7,14 @@ Find a Document
 You can retrieve a single document from a collection by using the
 ``FindOne()`` method.
 
-The following example passes a query filter to the ``FindOne()`` method,
-which matches documents in the ``movies`` collection where the value
-of the ``title`` field is *The Room*, returning the first document found.
+Example
+-------
 
 .. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example passes a query filter to the ``FindOne()`` method,
+which matches documents in the ``movies`` collection where the value
+of the ``title`` field is "The Room", returning the first document found:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
    :start-after: begin findOne

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example matches documents in the ``movies`` collection
-where the ``title`` field is "The Room", returning the first document 
+in which the ``title`` field is "The Room", returning the first document 
 matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -12,9 +12,9 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter to the ``FindOne()`` method,
-which matches documents in the ``movies`` collection where the value
-of the ``title`` field is "The Room", returning the first document found:
+The following example matches documents in the ``movies`` collection
+where the ``title`` field is "The Room", returning the first document 
+matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
    :start-after: begin findOne

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -12,8 +12,7 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example inserts two documents in the ``haikus`` collection
-of the ``insertDB`` database: 
+The following example inserts two documents in the ``haikus`` collection: 
 
 .. note:: Non-existent Database and Collections
 

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -12,8 +12,9 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example creates two new documents containing a ``title`` and ``text``
-field and inserts them into the ``haikus`` collection of the ``insertDB`` database:
+The following example passes two documents to the ``InsertMany()``
+method, which inserts them into the ``haikus`` collection of the
+``insertDB`` database: 
 
 .. note:: Non-existent Database and Collections
 

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -12,9 +12,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes two documents to the ``InsertMany()``
-method, which inserts them into the ``haikus`` collection of the
-``insertDB`` database: 
+The following example inserts two documents in the ``haikus`` collection
+of the ``insertDB`` database: 
 
 .. note:: Non-existent Database and Collections
 

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -7,16 +7,18 @@ Insert Multiple Documents
 You can insert multiple documents into a collection by using the ``InsertMany()``
 method.
 
-The following example creates a two new document containing a ``title`` and ``text``
-field and inserts it into the ``haikus`` collection of the ``insertDB`` database:
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example creates two new documents containing a ``title`` and ``text``
+field and inserts them into the ``haikus`` collection of the ``insertDB`` database:
 
 .. note:: Non-existent Database and Collections
 
     The driver automatically creates the necessary database and/or collection
     when you perform a write operation against them if they don't already exist.
-
-
-.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/insertMany.go
    :start-after: begin insertMany

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -12,8 +12,7 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example inserts a document in the ``haikus`` collection
-of the ``insertDB`` database:
+The following example inserts a document in the ``haikus`` collection:
 
 .. note:: Non-existent Database and Collections
 

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -12,9 +12,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a new document to the ``InsertOne()``
-method, which inserts it into the ``haikus`` collection of the
-``insertDB`` database: 
+The following example inserts a document in the ``haikus`` collection
+of the ``insertDB`` database:
 
 .. note:: Non-existent Database and Collections
 

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -12,8 +12,9 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example creates a new document containing a ``title`` and ``text``
-field and inserts it into the ``haikus`` collection of the ``insertDB`` database:
+The following example passes a new document to the ``InsertOne()``
+method, which inserts it into the ``haikus`` collection of the
+``insertDB`` database: 
 
 .. note:: Non-existent Database and Collections
 

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -7,6 +7,11 @@ Insert a Document
 You can insert a document into a collection by using the ``InsertOne()``
 method.
 
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
 The following example creates a new document containing a ``title`` and ``text``
 field and inserts it into the ``haikus`` collection of the ``insertDB`` database:
 
@@ -14,9 +19,6 @@ field and inserts it into the ``haikus`` collection of the ``insertDB`` database
 
     The driver automatically creates the necessary database and/or collection
     when you perform a write operation against them if they don't already exist.
-
-
-.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/insertOne.go
    :start-after: begin insertOne

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following on the ``haikus``
 collection:
 
-- Match a document in the where the ``title`` field is "Record of a Shriveled Datum"
-- Replace the matched document with a new document
+- Matches a document in which the ``title`` field is "Record of a Shriveled Datum"
+- Replaces the matched document with a new document
 
 .. literalinclude:: /includes/usage-examples/code-snippets/replace.go
    :start-after: begin replace

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -12,7 +12,7 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example specifies a query filter and replacement document
+The following example passes a query filter and replacement document
 to the ``ReplaceOne()`` method, which matches a document in the
 ``haikus`` collection where the ``title`` field is "Record of a
 Shriveled Datum" and replaces it with a document that contains a

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -12,11 +12,11 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter and replacement document
-to the ``ReplaceOne()`` method, which matches a document in the
-``haikus`` collection where the ``title`` field is "Record of a
-Shriveled Datum" and replaces it with a document that contains a
-``title`` and ``text`` field about a haiku:
+The following example performs the following on the ``haikus``
+collection:
+
+- Match a document in the where the ``title`` field is "Record of a Shriveled Datum"
+- Replace the matched document with a new document
 
 .. literalinclude:: /includes/usage-examples/code-snippets/replace.go
    :start-after: begin replace

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -7,13 +7,16 @@ Replace a Document
 You can replace a document in a collection by using the ``ReplaceOne()``
 method.
 
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
 The following example specifies a query filter and replacement document
 to the ``ReplaceOne()`` method, which matches a document in the
 ``haikus`` collection where the ``title`` field is "Record of a
 Shriveled Datum" and replaces it with a document that contains a
 ``title`` and ``text`` field about a haiku:
-
-.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/replace.go
    :start-after: begin replace

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -15,7 +15,7 @@ Example
 The following example performs the following on the ``haikus``
 collection:
 
-- Matches a document in which the ``title`` field is "Record of a Shriveled Datum"
+- Matches a document in which the ``title`` is "Record of a Shriveled Datum"
 - Replaces the matched document with a new document
 
 .. literalinclude:: /includes/usage-examples/code-snippets/replace.go

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -12,10 +12,10 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following code declares a ``BlogPost`` struct, in which the
-``WordCount`` has a struct tag that sets a custom BSON field name
-of ``word_count``. By default, the driver marshals the other fields as
-the lowercase of the struct field name:
+The following code declares a struct of type ``BlogPost``. This struct
+contains a struct tag that maps the ``WordCount`` field to the BSON
+field name ``word_count``. By default, the driver marshals the other
+fields as the lowercase of the struct field name:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/struct-tag.go
    :start-after: begin struct

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -7,6 +7,11 @@ Use Struct Tags
 You can specify the way that the Go Driver converts Go
 structs to :manual:`BSON </reference/bson-types/>` by using struct tags.
 
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
 The following code declares a ``BlogPost`` struct, where the ``WordCount`` field
 has a struct tag that sets a custom BSON field name of ``word_count``.
 By default, the driver marshals the other fields as the lowercase of the struct

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following code declares a ``BlogPost`` struct, in which the
-``WordCount`` field has a struct tag that sets a custom BSON field name
+``WordCount`` has a struct tag that sets a custom BSON field name
 of ``word_count``. By default, the driver marshals the other fields as
 the lowercase of the struct field name:
 

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -12,10 +12,10 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following code declares a ``BlogPost`` struct, where the ``WordCount`` field
-has a struct tag that sets a custom BSON field name of ``word_count``.
-By default, the driver marshals the other fields as the lowercase of the struct
-field name:
+The following code declares a ``BlogPost`` struct, in which the
+``WordCount`` field has a struct tag that sets a custom BSON field name
+of ``word_count``. By default, the driver marshals the other fields as
+the lowercase of the struct field name:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/struct-tag.go
    :start-after: begin struct

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following on the
 ``listingsAndReviews`` collection:
 
-- Match documents where the ``address.market`` field is "Sydney"
-- Multiply the ``price`` field in the matched documents by 1.15
+- Matches documents in which the ``address.market`` field is "Sydney"
+- Multiplies the ``price`` field in the matched documents by 1.15
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateMany.go
    :start-after: begin updatemany

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -12,11 +12,11 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter and an update parameter to the
-``UpdateMany()`` method, which matches documents in the
-``listingsAndReviews`` collection where the value of the ``address.market``
-field is "Sydney" and multiplies the ``price`` field in the matching
-documents by a factor of 1.15:
+The following example performs the following on the
+``listingsAndReviews`` collection:
+
+- Match documents where the ``address.market`` field is "Sydney"
+- Multiply the ``price`` field in the matched documents by 1.15
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateMany.go
    :start-after: begin updatemany

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -7,13 +7,16 @@ Update Multiple Documents
 You can update multiple documents in a collection by using the ``UpdateMany()``
 method.
 
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
 The following example passes a query filter and an update parameter to the
 ``UpdateMany()`` method, which matches documents in the
 ``listingsAndReviews`` collection where the value of the ``address.market``
 field is "Sydney" and multiplies the ``price`` field in the matching
-documents by a factor of *1.15*:
-
-.. include:: /includes/usage-examples/run-example-tip.rst
+documents by a factor of 1.15:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateMany.go
    :start-after: begin updatemany

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following on the
 ``listingsAndReviews`` collection:
 
-- Matches documents in which the ``address.market`` field is "Sydney"
-- Multiplies the ``price`` field in the matched documents by 1.15
+- Matches documents in which the ``address.market`` is "Sydney"
+- Multiplies the ``price`` in the matched documents by 1.15
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateMany.go
    :start-after: begin updatemany

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following on the
 ``listingsAndReviews`` collection:
 
-- Matches documents in which the ``address.market`` is "Sydney"
-- Multiplies the ``price`` in the matched documents by 1.15
+- Matches documents in which the market field of the address subdocument, ``address.market`` is "Sydney"
+- Updates the ``price`` in the matched documents by 1.15 times
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateMany.go
    :start-after: begin updatemany

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -7,12 +7,15 @@ Update a Document
 You can update a document in a collection by using the ``UpdateOne()``
 method. 
 
+Example
+-------
+
+.. include:: /includes/usage-examples/run-example-tip.rst
+
 The following example passes a query filter and an update parameter to the
 ``UpdateOne()`` method, which matches a document in the ``restaurants`` collection
 by the value of its ``_id`` field and creates a new field in that document called
-``avg_rating`` with a value of *4.4*:
-
-.. include:: /includes/usage-examples/run-example-tip.rst
+``avg_rating`` with a value of 4.4:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateOne.go
    :start-after: begin updateone

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -15,7 +15,7 @@ Example
 The following example performs the following on the ``restaurants``
 collection:
 
-- Matches a document with a specific ``_id`` field 
+- Matches a document with a specific ``_id`` 
 - Creates a new field in the matched document called ``avg_rating`` with a value of 4.4
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateOne.go

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -12,10 +12,11 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes a query filter and an update parameter to the
-``UpdateOne()`` method, which matches a document in the ``restaurants`` collection
-by the value of its ``_id`` field and creates a new field in that document called
-``avg_rating`` with a value of 4.4:
+The following example performs the following on the ``restaurants``
+collection:
+
+- Match a document with a specific ``_id`` field 
+- Create a new field in the matched document called ``avg_rating`` with a value of 4.4
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateOne.go
    :start-after: begin updateone

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -15,8 +15,8 @@ Example
 The following example performs the following on the ``restaurants``
 collection:
 
-- Match a document with a specific ``_id`` field 
-- Create a new field in the matched document called ``avg_rating`` with a value of 4.4
+- Matches a document with a specific ``_id`` field 
+- Creates a new field in the matched document called ``avg_rating`` with a value of 4.4
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateOne.go
    :start-after: begin updateone

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -13,7 +13,7 @@ Example
 .. include:: /includes/usage-examples/run-example-tip.rst
 
 The following example opens a change stream on the ``haikus`` collection
-and print inserted documents:
+and prints inserted documents:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/watch.go
    :start-after: begin watch

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -12,9 +12,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example passes in a pipeline to the ``Watch()`` method,
-which opens a change stream on the ``haikus`` collection and prints
-inserted documents: 
+The following example opens a change stream on the ``haikus`` collection
+and print inserted documents:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/watch.go
    :start-after: begin watch

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -7,10 +7,14 @@ Watch for Changes
 You can open a change stream on a ``MongoCollection``,
 ``MongoDatabase``, or ``MongoClient`` by using the ``Watch()`` method.
 
-The following example uses the ``Watch()`` method, to open a change
-stream on the ``haikus`` collection and prints inserted documents:
+Example
+-------
 
 .. include:: /includes/usage-examples/run-example-tip.rst
+
+The following example passes in a pipeline to the ``Watch()`` method,
+which opens a change stream on the ``haikus`` collection and prints
+inserted documents: 
 
 .. literalinclude:: /includes/usage-examples/code-snippets/watch.go
    :start-after: begin watch


### PR DESCRIPTION
## Pull Request Info

Updated all example sections to the following:
- Contain an Example heading
- Move the tip box before the example statement starts

The example statements have the following formats: (omitting the parameters and method name now)
- For a list of actions: `“The following example performs ...”` 
- For non-list actions: `“The following example matches ...”`
- For insert pages: `“The following example inserts ...”`
- For watch: `“The following example opens ...”`
- For command: `“The following example retrieves ...”`
- For struct-tagging: `“The following example creates ...”`

NOTE: Only the watch page shows how to print because that showcases how to best use it

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18444

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61390773c608bec57f8cd9e6

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18444-ExampleSection/usage-examples/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
