### PR TITLE
DOCSP-18445 results sections

### DIFF
--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -40,7 +40,7 @@ document in the ``haikus`` collection:
    }
 
 For an example on how to find a document, see our :doc:`Find
-One Usage Example </usage-examples/findOne>`.
+a Document Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -27,7 +27,7 @@ Click `here <{+example+}/bulk.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding code snippet, you should be able to find the
+After you run the preceding example, you should be able to find the
 document in the ``haikus`` collection:
 
 .. code-block:: json

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -27,8 +27,8 @@ Click `here <{+example+}/bulk.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you should be able to find the
-document in the ``haikus`` collection:
+After you run the preceding example, you can find the following document
+in the ``haikus`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -25,8 +25,8 @@ Click `here <{+example+}/command.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-The example returns a ``SingleResult`` type that contains the following
-values:
+After you run the preceding example, it returns a ``SingleResult`` type
+that contains the following values:
 
 .. code-block:: json
 

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -29,7 +29,7 @@ Click `here <{+example+}/count.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After running the preceding code snippet, you should see the following:
+After you run the preceding example, you should see the following:
 
 - There are about ``23541`` documents in the ``movies`` collection
 - There are ``303`` documents in the ``movies`` collection from "China"

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -32,7 +32,7 @@ Expected Result
 After you run the preceding example, you should see the following:
 
 - There are about ``23541`` documents in the ``movies`` collection
-- There are ``303`` documents in the ``movies`` collection from "China"
+- There are ``303`` documents in the ``movies`` collection that contain "China" in the ``countries`` field
 
 .. note::
 

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -26,8 +26,8 @@ Click here <TODO> to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you should not be able to find
-the following documents in the ``movies`` collection:
+After you run the preceding example, you cannot find the following
+documents in the ``movies`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -39,7 +39,7 @@ the following documents in the ``movies`` collection:
    { "_id": ObjectId("573a13a6f29313caabd18ae0"), ... , "runtime": 877, ... }
 
 For an example on how to find multiple documents, see our :doc:`Find
-Usage Example </usage-examples/find>`.
+Multiple Documents Usage Example </usage-examples/find>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -26,7 +26,7 @@ Click here <TODO> to see a fully runnable example.
 Expected Result
 ---------------
 
-After running the preceding code snippet, you should not be able to find
+After you run the preceding example, you should not be able to find
 the following documents in the ``movies`` collection:
 
 .. code-block:: json

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -26,8 +26,8 @@ Click here <TODO> to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you cannot find the following
-documents in the ``movies`` collection:
+After you run the preceding example, it removes the following documents
+in the ``movies`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -26,7 +26,7 @@ Click here <TODO> to see a fully runnable example.
 Expected Result
 ---------------
 
-After running the preceding code snippet, you should not be able to find
+After you run the preceding example, you should not be able to find
 the following document in the ``movies`` collection:
 
 .. code-block:: json

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -36,7 +36,7 @@ the following document in the ``movies`` collection:
    { "_id": ObjectId("573a13bff29313caabd5e06b"), ..., "title": "Twilight", ... }
 
 For an example on how to find a document, see our :doc:`Find
-One Usage Example </usage-examples/findOne>`.
+a Document Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -26,8 +26,8 @@ Click here <TODO> to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you should not be able to find
-the following document in the ``movies`` collection:
+After you run the preceding example, you cannot find the following
+document in the ``movies`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -26,8 +26,8 @@ Click here <TODO> to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you cannot find the following
-document in the ``movies`` collection:
+After you run the preceding example, it removes the following document
+in the ``movies`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -26,8 +26,8 @@ Click `here <{+example+}/distinct.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-The example returns an empty slice of an ``interface`` type that
-contains the following values:
+After you run the preceding example, it returns an empty slice of an
+``interface`` type that contains the following values:
 
 .. code-block:: none
    :copyable: false

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -25,8 +25,8 @@ Click `here <{+example+}/find.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, it returns a ``Cursor`` object that
-contains the following documents:
+After you run the preceding example, it created a ``Cursor`` object that
+returns the following documents:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -25,8 +25,8 @@ Click `here <{+example+}/find.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-This example creates a ``Cursor`` object that returns
-documents similar to these:
+After you run the preceding example, it returns a ``Cursor`` object that
+contains the following documents:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -25,7 +25,7 @@ Click `here <{+example+}/find.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, it created a ``Cursor`` object that
+After you run the preceding example, it creates a ``Cursor`` object that
 returns the following documents:
 
 .. code-block:: json

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -26,7 +26,7 @@ Expected Result
 ---------------
 
 After you run the preceding example, it returns a ``SingleResult``
-object with the following document:
+object that contains the following document:
 
 .. code-block:: json
    :copyable: False

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -25,7 +25,8 @@ Click `here <{+example+}/findOne.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you should see output similar to:
+After you run the preceding example, it returns a ``SingleResult``
+object with the following document:
 
 .. code-block:: json
    :copyable: False

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -25,7 +25,7 @@ Click `here <{+example+}/findOne.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the code example, you should see output similar to:
+After you run the preceding example, you should see output similar to:
 
 .. code-block:: json
    :copyable: False

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -48,7 +48,7 @@ collection with an ``_id`` field that matches the previous output:
    }
 
 For an example on how to find multiple documents, see our :doc:`Find
-Usage Example </usage-examples/find>`.
+Multiple Documents Usage Example </usage-examples/find>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -30,8 +30,8 @@ Click `here <{+example+}/insertMany.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, two new documents will be present in the
-collection with an ``_id`` field that matches the previous output:
+After you run the preceding example, you can find the inserted documents
+in the ``haikus`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -30,8 +30,8 @@ Click `here <{+example+}/insertMany.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you can find the inserted documents
-in the ``haikus`` collection:
+After you run the preceding example, you can find the following inserted
+documents in the ``haikus`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -30,7 +30,7 @@ Click `here <{+example+}/insertMany.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the code example, two new documents will be present in the
+After you run the preceding example, two new documents will be present in the
 collection with an ``_id`` field that matches the previous output:
 
 .. code-block:: json
@@ -46,6 +46,9 @@ collection with an ``_id`` field that matches the previous output:
      "title": "Showcasing a Blossoming Binary",
      "text": "Binary data, safely stored with GridFS. Bucket the data"
    }
+
+For an example on how to find multiple documents, see our :doc:`Find
+Usage Example </usage-examples/find>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -43,7 +43,7 @@ collection with an ``_id`` field that matches the previous output:
    }
 
 For an example on how to find a document, see our :doc:`Find
-One Usage Example </usage-examples/findOne>`.
+a Document Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -30,7 +30,7 @@ Click `here <{+example+}/insertOne.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the code example, a new document will be present in the
+After you run the preceding example, a new document will be present in the
 collection with an ``_id`` field that matches the previous output:
 
 .. code-block:: json
@@ -41,6 +41,9 @@ collection with an ``_id`` field that matches the previous output:
      "title": "Record of a Shriveled Datum",
      "text": "No bytes, no problem. Inserting a document. In MongoDB"
    }
+
+For an example on how to find a document, see our :doc:`Find
+One Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -30,8 +30,8 @@ Click `here <{+example+}/insertOne.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, a new document will be present in the
-collection with an ``_id`` field that matches the previous output:
+After you run the preceding example, you can find the inserted document
+in the ``haikus`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -30,8 +30,8 @@ Click `here <{+example+}/insertOne.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you can find the inserted document
-in the ``haikus`` collection:
+After you run the preceding example, you can find the following inserted
+document in the ``haikus`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -27,7 +27,7 @@ Click `here <{+example+}/replace.go>`__  to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding code snippet, you should be able to find the
+After you run the preceding example, you should be able to find the
 replacement document in the ``haikus`` collection:
 
 .. code-block:: json

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -40,7 +40,7 @@ replacement document in the ``haikus`` collection:
    }
 
 For an example on how to find a document, see our :doc:`Find
-One Usage Example </usage-examples/findOne>`.
+a Document Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -27,8 +27,8 @@ Click `here <{+example+}/replace.go>`__  to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you can find the replaced document
-in the ``haikus`` collection:
+After you run the preceding example, you can find the following replaced
+document in the ``haikus`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -27,8 +27,8 @@ Click `here <{+example+}/replace.go>`__  to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you should be able to find the
-replacement document in the ``haikus`` collection:
+After you run the preceding example, you can find the replaced document
+in the ``haikus`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -36,8 +36,8 @@ Click `here <{+example+}/struct-tag.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you should be able to find
-the following document in the ``posts`` collection:
+After you run the preceding example, you can find the following document
+in the ``posts`` collection:
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -52,7 +52,7 @@ the following document in the ``posts`` collection:
    }
 
 For an example on how to find a document, see our :doc:`Find
-One Usage Example </usage-examples/findOne>`.
+a Document Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -36,7 +36,7 @@ Click `here <{+example+}/struct-tag.go>`__ to see a fully runnable example.
 Expected Result
 ---------------
 
-After running the preceding code snippet, you should be able to find
+After you run the preceding example, you should be able to find
 the following document in the ``posts`` collection:
 
 .. code-block:: json
@@ -52,7 +52,7 @@ the following document in the ``posts`` collection:
    }
 
 For an example on how to find a document, see our :doc:`Find
-A Document Usage Example </usage-examples/findOne>`.
+One Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -27,9 +27,8 @@ Click here **<TODO: github link to file>** to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, the ``price`` field of the matched
-documents will reflect the multiplication. The updated documents will
-appear similar to these:
+After you run the preceding example, you can find the updated documents
+in the ``listingsAndReviews`` collection: 
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -42,7 +42,7 @@ appear similar to these:
    ...
 
 For an example on how to find multiple documents, see our :doc:`Find
-Usage Example </usage-examples/find>`.
+Multiple Documents Usage Example </usage-examples/find>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -27,8 +27,8 @@ Click here **<TODO: github link to file>** to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you can find the updated documents
-in the ``listingsAndReviews`` collection: 
+After you run the preceding example, you can find the following updated
+documents in the ``listingsAndReviews`` collection: 
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -27,7 +27,7 @@ Click here **<TODO: github link to file>** to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the code example, the ``price`` field of the matched
+After you run the preceding example, the ``price`` field of the matched
 documents will reflect the multiplication. The updated documents will
 appear similar to these:
 
@@ -40,6 +40,9 @@ appear similar to these:
    { "_id" : "9908871", ... , "name" : "Family friendly beach house", ... , "price" : 751.00, ... },
    { "_id" : "20989061", ... , "name" : "Big and sunny Narraben room", ... , "price" : 60.00, ... },
    ...
+
+For an example on how to find multiple documents, see our :doc:`Find
+Usage Example </usage-examples/find>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -26,8 +26,8 @@ Click here **<TODO: github link to file>** to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, the document will include the
-``avg_rating`` field with the specified value:
+After you run the preceding example, you can find the updated document
+in the ``restaurants`` collection: 
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -26,7 +26,7 @@ Click here **<TODO: github link to file>** to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the code example, the document will include the
+After you run the preceding example, the document will include the
 ``avg_rating`` field with the specified value:
 
 .. code-block:: json
@@ -40,6 +40,9 @@ After you run the code example, the document will include the
       "restaurant_id" : "40372112",
       "avg_rating" : 4.4
    }
+
+For an example on how to find a document, see our :doc:`Find
+One Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -42,7 +42,7 @@ After you run the preceding example, the document will include the
    }
 
 For an example on how to find a document, see our :doc:`Find
-One Usage Example </usage-examples/findOne>`.
+a Document Usage Example </usage-examples/findOne>`.
 
 Additional Information
 ----------------------

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -26,8 +26,8 @@ Click here **<TODO: github link to file>** to see a fully runnable example.
 Expected Result
 ---------------
 
-After you run the preceding example, you can find the updated document
-in the ``restaurants`` collection: 
+After you run the preceding example, you can find the following updated
+document in the ``restaurants`` collection: 
 
 .. code-block:: json
    :copyable: false

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -26,8 +26,8 @@ Expected Result
 
 After you run the preceding example, run the :doc:`Insert a
 Document usage example </usage-examples/insertOne>` in a different
-shell. Once you run the insert operation, you should see output similar
-to the following:
+shell. Once you run the insert operation, you should see the following
+output: 
 
 .. code-block:: json
    :copyable: false


### PR DESCRIPTION
## Pull Request Info

 Updated all results sections to the following:
- The wording with the format:  `"After you run the preceding example, ..."`
- Link to the find pages to show how you can view the result of what was just done (all CRUD pages)

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18445

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6137e2ae7dcf0129309016b0

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18445-ResultsSection/usage-examples/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
