### PR TITLE
update api links to 1.7.2

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -13,6 +13,6 @@ intersphinx = [
 
 [constants]
 docs-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
-version = "v1.7.0" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
+version = "v1.7.2" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
 example = "https://raw.githubusercontent.com/mongodb/docs-golang/{+docs-branch+}/source/includes/usage-examples/code-snippets"
 api = "https://pkg.go.dev/go.mongodb.org/mongo-driver@{+version+}"

--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -25,26 +25,26 @@ Supported Mechanisms
 --------------------
 
 The Go Driver establishes a connection with an authentication mechanism
-through a `Client <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.1/mongo#Client>`__
+through a `Client <{+api+}/mongo#Client>`__
 type. The ``Client`` type specifies the mechanism and credentials to use
-as connection options in a `Credential <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.1/mongo/options#Credential>`__
+as connection options in a `Credential <{+api+}/mongo/options#Credential>`__
 type . To configure these options, pass a ``Credential`` type to the
-`SetAuth() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.1/mongo/options#ClientOptions.SetAuth>`__ 
-function of the `ClientOptions <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.1/mongo/options#ClientOptions>`__
-type. 
+`SetAuth() <{+api+}/mongo/options#ClientOptions.SetAuth>`__
+function of the `ClientOptions <{+api+}/mongo/options#ClientOptions>`__
+type.
 
 The following sections demonstrate this process with the five
-mechanisms the MongoDB Community Edition supports. 
+mechanisms the MongoDB Community Edition supports.
 
 Example Conventions
 ~~~~~~~~~~~~~~~~~~~
 
-Each authentication mechanism contains the following placeholders: 
+Each authentication mechanism contains the following placeholders:
 
 * ``username`` - Your MongoDB username
 * ``password`` - Your MongoDB user's password
 * ``hostname`` - Your MongoDB servers network address, accessible by
-  your client 
+  your client
 * ``port`` - Your MongoDB servers port number
 * ``authenticationDb`` - Your MongoDB database that contains the user's
   authentication data. If you omit this option, the driver uses the
@@ -67,8 +67,8 @@ mechanisms depending on what MongoDB versions your server supports:
      - Versions
 
    * - ``SCRAM-SHA-256``
-     - MongoDB 4.0 and later   
-   
+     - MongoDB 4.0 and later
+
    * - ``SCRAM-SHA-1``
      - MongoDB 3.0, 3.2, 3.4, and 3.6
 
@@ -107,7 +107,7 @@ see the :manual:`SCRAM </core/security-scram/>` section of the server manual.
 algorithm, to authenticate your user.
 
 To specify the ``SCRAM-SHA-256`` authentication mechanism, assign the
-``AuthMechanism`` option the value ``"SCRAM-SHA-256"``:  
+``AuthMechanism`` option the value ``"SCRAM-SHA-256"``:
 
 .. code-block:: go
    :emphasize-lines: 2
@@ -120,7 +120,7 @@ To specify the ``SCRAM-SHA-256`` authentication mechanism, assign the
    }
    clientOpts := options.Client().ApplyURI("mongodb://<hostname>:<port>").
       SetAuth(credential)
-   
+
    client, err := mongo.Connect(context.TODO(), clientOpts)
 
 .. _scram-sha-1-auth-mechanism:
@@ -138,7 +138,7 @@ username and password, encrypted with the ``SHA-1`` algorithm, to authenticate
 your user.
 
 To specify the ``SCRAM-SHA-1`` authentication mechanism, assign the
-``AuthMechanism`` option the value ``"SCRAM-SHA-1"``:  
+``AuthMechanism`` option the value ``"SCRAM-SHA-1"``:
 
 .. code-block:: go
    :emphasize-lines: 2
@@ -203,7 +203,7 @@ following:
    _ = awsIAMClient
 
 If you need to specify an AWS session token, use the temporary
-credentials returned from an assume role request. 
+credentials returned from an assume role request.
 
 To use temporary credentials, assign the ``AuthMechanismProperties``
 option the value of your ``sessionToken``:

--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -43,15 +43,14 @@ than 100:
    filter := bson.D{{"quantity", bson.D{{"$gt", 100}}}}
 
 For more information on how the Go Driver handles BSON data, see the
-`bson package API documentation
-<https://pkg.go.dev/go.mongodb.org/mongo-driver/bson>`_.
+`bson package API documentation <{+api+}/bson>`__.
 
 Struct Tags
 -----------
 
 In Go, a **struct** is a collection of data fields with declared data
 types. The Go Driver can marshal/unmarshal structs and other native Go
-types to/from BSON using a `configurable codec system <https://pkg.go.dev/go.mongodb.org/mongo-driver/bson/bsoncodec>`_.
+types to/from BSON using a `configurable codec system <{+api+}/bson/bsoncodec>`_.
 
 You can modify the default marshalling and unmarshalling behavior of the Go Driver using
 **struct tags**, which are optional pieces of metadata attached to
@@ -100,8 +99,8 @@ Driver will marshal structs using the following rules:
    pointer is non-nil. If the pointer is nil, the driver marshals it as a BSON null
    value.
 
-#. When unmarshalling, the Go Driver follows `these D/M type mappings
-   <https://pkg.go.dev/go.mongodb.org/mongo-driver/bson#hdr-Native_Go_Types>`_
+#. When unmarshalling, the Go Djiver follows `these D/M type mappings
+   <{+api+}/bson#hdr-Native_Go_Types>`_
    for fields of type ``interface{}``. The driver unmarshals BSON documents
    unmarshalled into an ``interface{}`` field as a ``D`` type.
 
@@ -291,9 +290,8 @@ The output of the preceding code should look like this:
    unmarshalling the entire BSON document.
 
 For more information on the marshalling and unmarshalling methods used with the
-``Cursor`` type, see the `Cursor API documentation
-<https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Cursor>`_
+``Cursor`` type, see the `Cursor API documentation <{+api+}/mongo#Cursor>`__
 
 For more information on the marshalling and unmarshalling methods in the
 ``bson`` package, see the `bson API documentation
-<https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/bson#hdr-Marshalling_and_Unmarshalling>`_
+<{+api+}/bson#hdr-Marshalling_and_Unmarshalling>`_

--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -99,7 +99,7 @@ Driver will marshal structs using the following rules:
    pointer is non-nil. If the pointer is nil, the driver marshals it as a BSON null
    value.
 
-#. When unmarshalling, the Go Djiver follows `these D/M type mappings
+#. When unmarshalling, the Go Driver follows `these D/M type mappings
    <{+api+}/bson#hdr-Native_Go_Types>`_
    for fields of type ``interface{}``. The driver unmarshals BSON documents
    unmarshalled into an ``interface{}`` field as a ``D`` type.

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -213,4 +213,4 @@ URI to specify the behavior of the client.
 
 For a full list of connection options, see the `ClientOptions API
 documentation
-<https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo/options#ClientOptions>`__.
+<{+api+}/mongo/options#ClientOptions>`__.

--- a/source/fundamentals/context.txt
+++ b/source/fundamentals/context.txt
@@ -15,9 +15,9 @@ Overview
 
 The MongoDB Go Driver uses the `context package
 <https://pkg.go.dev/context>`__ from Go's standard library to allow
-applications to signal timeouts and cancellations for any **blocking function** 
+applications to signal timeouts and cancellations for any **blocking function**
 call. A blocking function relies on an external event, such as a network
-input or output, to proceed with its task. 
+input or output, to proceed with its task.
 
 An example of a blocking function in the Go Driver is the ``Insert()``
 function. If you want to perform an insert operation on a ``Collection``
@@ -39,36 +39,36 @@ Expiration
 
 The driver considers a Context expired when an operation exceeds its
 timeout or is canceled. The driver checks the Context expiration with
-the ``Done()`` function. 
+the ``Done()`` function.
 
 The following sections describe when and how the driver checks for
-expiration. 
+expiration.
 
 Server Selection
 ~~~~~~~~~~~~~~~~
 
 The driver might block a function call if it can't select a server for
-an operation. 
+an operation.
 
 In this scenario, the driver loops until it finds a server to use for the
 operation. After each iteration, the driver returns a server selection
 timeout error if the Context expired or the selection process took
-longer than the ``serverSelectionTimeoutMS`` setting. 
+longer than the ``serverSelectionTimeoutMS`` setting.
 
 For more information on how the driver selects a server, see the
-:ref:`<replica-set-read-preference-behavior>`. 
+:ref:`<replica-set-read-preference-behavior>`.
 
 Connection Checkout
 ~~~~~~~~~~~~~~~~~~~
 
 The driver might block a function call if there are no available
-connections to check out. 
+connections to check out.
 
 After selecting a server, the driver tries to check out a connection
 from the server’s connection pool. If the Context expires while checking
-out a connection, the function returns a timeout error. 
+out a connection, the function returns a timeout error.
 
-Connection Establishment 
+Connection Establishment
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The driver might block an function call if it needs to create a new
@@ -77,7 +77,7 @@ connection.
 When the driver needs to create a new connection to execute an
 operation, the Context sets a timeout for the establishment process. The
 driver sets the timeout to either the Context expiration or connection
-timeout, whichever is shorter. 
+timeout, whichever is shorter.
 
 The following example sets the connection timeout to *1* second and the
 Context deadline to *2* seconds. Because the connection timeout is
@@ -93,7 +93,7 @@ shorter, the establishment process expires after *1* second.
     ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
     defer cancel()
     client.Database("<db>").Collection("<collection>").InsertOne(ctx, bson.D{{"x",1}})
-    
+
 Socket Read and Write
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -101,19 +101,19 @@ When the driver retrieves a connection for an operation, it sets the
 socket’s read or write deadline to either the Context deadline or socket
 timeout, whichever is shorter.
 
-.. important:: 
+.. important::
 
     If you cancel the Context after the execution of the ``Read()`` or
     ``Write()`` function but before its deadline, the behavior of the driver
-    differs based on version. 
+    differs based on version.
 
 In versions prior to 1.5.0, the driver doesn't detect the Context
 cancellation and waits for the ``Read()`` or ``Write()`` function to
-return. 
+return.
 
 In versions 1.5.0 and later, the driver generates a separate
 goroutine to listen for Context cancellation when the ``Read()`` or
 ``Write()`` function is in progress. If the goroutine detects a
 cancellation, it closes the connection. The pending ``Read()`` or
 ``Write()`` function returns an error which the driver overwrites with
-the ``context.Canceled`` error. 
+the ``context.Canceled`` error.

--- a/source/index.txt
+++ b/source/index.txt
@@ -11,7 +11,7 @@ MongoDB Go Driver
    /quick-start
    /usage-examples
    /fundamentals
-   API Documentation <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo>
+   API Documentation <{+api+}/mongo>
    /issues-and-help
    /compatibility
 
@@ -62,7 +62,7 @@ API
 ---
 
 See the `API Documentation
-<https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo>`__ if you are
+<{+api+}/mongo>`__ if you are
 looking for technical information about types, functions, and
 configuration objects within the MongoDB Go Driver.
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -51,4 +51,4 @@ Additional Information
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-`DeleteOne() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.DeleteOne>`__
+`DeleteOne() <{+api+}/mongo#Collection.DeleteOne>`__

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -55,5 +55,5 @@ see the :manual:`MongoDB query operator reference documentation
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-- `Find() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.Find>`__
-- `Cursor <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Cursor>`__
+- `Find() <{+api+}/mongo#Collection.Find>`__
+- `Cursor <{+api+}/mongo#Cursor>`__

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -59,4 +59,4 @@ see the :manual:`MongoDB update operator reference documentation
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-`UpdateMany() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.UpdateMany>`__
+`UpdateMany() <{+api+}/mongo#Collection.UpdateMany>`__

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -61,4 +61,4 @@ see the :manual:`MongoDB update operator reference documentation
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-`UpdateOne() <https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.7.0/mongo#Collection.UpdateOne>`__
+`UpdateOne() <{+api+}/mongo#Collection.UpdateOne>`__


### PR DESCRIPTION
## Pull Request Info
This also removes all other uses of the URL https://pkg.go.dev/... to link to the API docs and uses the [`{+api+}`](url) constant instead. 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18729

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61436710c608bec57fc80970

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18729/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
  - Caveat: Fixing other broken links in a new PR. All changed links were checked.
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
