### PR TITLE
DOCSP-18735

### DIFF
--- a/source/fundamentals/context.txt
+++ b/source/fundamentals/context.txt
@@ -15,13 +15,13 @@ Overview
 
 The MongoDB Go Driver uses the `context package
 <https://pkg.go.dev/context>`__ from Go's standard library to allow
-applications to signal timeouts and cancellations for any **blocking function** 
+applications to signal timeouts and cancellations for any **blocking function**
 call. A blocking function relies on an external event, such as a network
-input or output, to proceed with its task. 
+input or output, to proceed with its task.
 
 An example of a blocking function in the Go Driver is the ``Insert()``
 function. If you want to perform an insert operation on a ``Collection``
-within 10 seconds, you can use a ``Context`` with a timeout. If the
+within 10 seconds, you can use a Context with a timeout. If the
 operation doesn't complete within the timeout, the function returns
 an error.
 
@@ -39,36 +39,36 @@ Expiration
 
 The driver considers a Context expired when an operation exceeds its
 timeout or is canceled. The driver checks the Context expiration with
-the ``Done()`` function. 
+the ``Done()`` function.
 
 The following sections describe when and how the driver checks for
-expiration. 
+expiration.
 
 Server Selection
 ~~~~~~~~~~~~~~~~
 
 The driver might block a function call if it can't select a server for
-an operation. 
+an operation.
 
 In this scenario, the driver loops until it finds a server to use for the
 operation. After each iteration, the driver returns a server selection
 timeout error if the Context expired or the selection process took
-longer than the ``serverSelectionTimeoutMS`` setting. 
+longer than the ``serverSelectionTimeoutMS`` setting.
 
 For more information on how the driver selects a server, see the
-:ref:`<replica-set-read-preference-behavior>`. 
+:ref:`<replica-set-read-preference-behavior>`.
 
 Connection Checkout
 ~~~~~~~~~~~~~~~~~~~
 
 The driver might block a function call if there are no available
-connections to check out. 
+connections to check out.
 
 After selecting a server, the driver tries to check out a connection
 from the server’s connection pool. If the Context expires while checking
-out a connection, the function returns a timeout error. 
+out a connection, the function returns a timeout error.
 
-Connection Establishment 
+Connection Establishment
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The driver might block an function call if it needs to create a new
@@ -77,7 +77,7 @@ connection.
 When the driver needs to create a new connection to execute an
 operation, the Context sets a timeout for the establishment process. The
 driver sets the timeout to either the Context expiration or connection
-timeout, whichever is shorter. 
+timeout, whichever is shorter.
 
 The following example sets the connection timeout to *1* second and the
 Context deadline to *2* seconds. Because the connection timeout is
@@ -101,19 +101,18 @@ When the driver retrieves a connection for an operation, it sets the
 socket’s read or write deadline to either the Context deadline or socket
 timeout, whichever is shorter.
 
-.. important:: 
+If you cancel the Context after the execution of the ``Read()`` or
+``Write()`` function but before its deadline, the behavior of the driver
+differs based on version.
 
-    If you cancel the Context after the execution of the ``Read()`` or
-    ``Write()`` function but before its deadline, the behavior of the driver
-    differs based on version. 
+The driver generates a separate goroutine to listen for Context
+cancellation when the ``Read()`` or ``Write()`` function is in progress.
+If the goroutine detects a cancellation, it closes the connection. The
+pending ``Read()`` or ``Write()`` function returns an error which the
+driver overwrites with the ``context.Canceled`` error.
 
-In versions prior to 1.5.0, the driver doesn't detect the Context
-cancellation and waits for the ``Read()`` or ``Write()`` function to
-return. 
+.. important::
 
-In versions 1.5.0 and later, the driver generates a separate
-goroutine to listen for Context cancellation when the ``Read()`` or
-``Write()`` function is in progress. If the goroutine detects a
-cancellation, it closes the connection. The pending ``Read()`` or
-``Write()`` function returns an error which the driver overwrites with
-the ``context.Canceled`` error. 
+    In versions prior to 1.5.0, the driver doesn't detect the Context
+    cancellation and waits for the ``Read()`` or ``Write()`` function to
+    return.


### PR DESCRIPTION
## Pull Request Info

Updated the Context page to:
- not monospace "Context"
- have an admonition in the last section about older versions of the driver

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18735

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61437e66c608bec57fd0927c

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18735/fundamentals/context/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
