### PR TITLE
DOCSP-18732 quick start page

### DIFF
--- a/source/includes/quick-start/atlas-setup.rst
+++ b/source/includes/quick-start/atlas-setup.rst
@@ -14,7 +14,7 @@ cluster deployed in Atlas, a new database user, and
 Connect to your Cluster
 -----------------------
 
-In this step, you will create and run an application that uses the Go
+In this step, you create and run an application that uses the Go
 driver to connect to your MongoDB cluster and run a query on the sample
 data.
 

--- a/source/includes/quick-start/atlas-setup.rst
+++ b/source/includes/quick-start/atlas-setup.rst
@@ -32,9 +32,9 @@ want to connect to as shown below.
 .. figure:: /includes/figures/atlas_connection_select_cluster.png
    :alt: Atlas Connection GUI cluster selection screen
 
-Proceed to the **Connect Your Application** step and select the Go driver.
-Then, select the "Connection String Only" tab and click the **Copy**
-button to copy the *connection string* to your clipboard as shown below.
+Proceed to the **Connect Your Application** step and select the Go
+driver. Then, click the **Copy** button to copy the *connection string*
+to your clipboard as shown below.
 
 .. figure:: /includes/figures/atlas_connection_copy_string.png
    :alt: Atlas Connection GUI connection string screen

--- a/source/includes/quick-start/main.go
+++ b/source/includes/quick-start/main.go
@@ -15,18 +15,16 @@ import (
 func main() {
 	uri := os.Getenv("MONGODB_URI")
 	if uri == "" {
-		log.Panic(`'uri' is empty. Ensure you set the 'MONGODB_URI'
-		environment variable, or set the value of 'uri' to your
-		Atlas connection string.`)
+		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
 	}
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	defer func() {
 		if err := client.Disconnect(context.TODO()); err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 	}()
 
@@ -40,12 +38,12 @@ func main() {
 		return
 	}
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	jsonData, err := json.MarshalIndent(result, "", "    ")
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	fmt.Printf("%s\n", jsonData)
 }

--- a/source/includes/quick-start/query-output.rst
+++ b/source/includes/quick-start/query-output.rst
@@ -1,5 +1,5 @@
-When you run ``main.go``, it should output the details of the
-movie from the sample dataset which will look something like this:
+When you run ``main.go``, it should output the details of the movie from
+the sample dataset which looks something like the following:
 
 .. code-block:: json
 
@@ -10,6 +10,6 @@ movie from the sample dataset which will look something like this:
        ...
    }
 
-If you receive no output or an error, check whether you included the proper
-connection string in your ``main.go`` file, and whether you loaded the
-sample dataset in your MongoDB Atlas cluster
+If you receive no output or an error, check whether you properly set up
+your environment variable and whether you loaded the sample dataset in
+your MongoDB Atlas cluster.

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -54,14 +54,14 @@ Set the value of the ``uri`` variable with your MongoDB Atlas connection
 string, or create an environmental variable with the name ``MONGODB_URI``
 with your Atlas connection string.
 
-.. code-block:: sh
+.. code-block:: bash
 
    export MONGODB_URI='<your atlas connection string>'
 
 .. note::
 
    Make sure to replace the "<password>" section of the connection string with
-   the password you created for your user that has **atlasAdmin** permissions:
+   the password you created for your user that has **atlasAdmin** permissions.
 
 .. literalinclude:: /includes/quick-start/main.go
    :language: go
@@ -69,10 +69,9 @@ with your Atlas connection string.
 
 Run the sample code with the following command from your command line:
 
-.. code-block:: shell
+.. code-block:: bash
 
    go run main.go
-
 
 .. include:: /includes/quick-start/query-output.rst
 
@@ -84,8 +83,6 @@ Run the sample code with the following command from your command line:
 After completing this step, you should have a working application that uses
 the Go driver to connect to your MongoDB cluster, run a query on the
 sample data, and print out the result.
-
-
 
 Next steps
 ----------


### PR DESCRIPTION
## Pull Request Info

Updated the quickstart page to:
- use `panic` instead of `log.Panic`
- have the correct atlas step to copy the connection string
- use env variable instead of talking about using connection string 
- not use future tense

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18732

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=614385d5c608bec57fd338db

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18732/quick-start/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
