### PR TITLE
Docsp 18736

### DIFF
--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -24,6 +24,20 @@ authentication mechanism, see our :doc:`Connection Guide </fundamentals/connecti
 Supported Mechanisms
 --------------------
 
+The Go driver supports the following authentication mechanisms:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - :ref:`SCRAM-SHA-256 <go_sha_256>`
+   * - :ref:`SCRAM-SHA-1 <go_sha_1>`
+   * - :ref:`MONGODB-CR <go_mongodb_cr>`
+   * - :ref:`MongoDB-AWS <go_mongodb_aws>`
+   * - :ref:`X.509 <go_x509>
+
+
+
 The Go Driver establishes a connection with an authentication mechanism
 through a `Client <{+api+}/mongo#Client>`__
 type. The ``Client`` type specifies the mechanism and credentials to use
@@ -94,6 +108,8 @@ For more information on the challenge-response (CR) and salted
 challenge-response authentication mechanisms (SCRAM) that MongoDB supports,
 see the :manual:`SCRAM </core/security-scram/>` section of the server manual.
 
+.. _go_sha_256:
+
 ``SCRAM-SHA-256``
 ~~~~~~~~~~~~~~~~~
 
@@ -124,6 +140,7 @@ To specify the ``SCRAM-SHA-256`` authentication mechanism, assign the
    client, err := mongo.Connect(context.TODO(), clientOpts)
 
 .. _scram-sha-1-auth-mechanism:
+.. _go_sha_1:
 
 ``SCRAM-SHA-1``
 ~~~~~~~~~~~~~~~
@@ -154,6 +171,8 @@ To specify the ``SCRAM-SHA-1`` authentication mechanism, assign the
 
    client, err := mongo.Connect(context.TODO(), clientOpts)
 
+.. _go_mongodb_cr:
+
 ``MONGODB-CR``
 ~~~~~~~~~~~~~~
 
@@ -164,6 +183,8 @@ username and password to authenticate your user.
 
    This authentication mechanism was deprecated starting in MongoDB 3.6
    and is no longer supported as of MongoDB 4.0.
+
+.. _go_mongodb_aws:
 
 ``MONGODB-AWS``
 ~~~~~~~~~~~~~~~
@@ -223,6 +244,8 @@ option the value of your ``sessionToken``:
    }
    assumeRoleClient, err := mongo.Connect(context.TODO(),
       options.Client().SetAuth(assumeRoleCredential))
+
+.. _go_x509:
 
 ``X.509``
 ~~~~~~~~~

--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -258,6 +258,7 @@ following:
 
    clientOpts := options.Client().ApplyURI(uri).SetAuth(credential)
 
-For more information on configuring your application to use
-certificates as well as TLS/SSL options, see our
-:doc:`TLS/SSL guide </fundamentals/connection/tls>`.
+..
+  For more information on configuring your application to use
+  certificates as well as TLS/SSL options, see our
+  :doc:`TLS/SSL guide </fundamentals/connection/tls>`.

--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -26,17 +26,11 @@ Supported Mechanisms
 
 The Go driver supports the following authentication mechanisms:
 
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-
-   * - :ref:`SCRAM-SHA-256 <go_sha_256>`
-   * - :ref:`SCRAM-SHA-1 <go_sha_1>`
-   * - :ref:`MONGODB-CR <go_mongodb_cr>`
-   * - :ref:`MongoDB-AWS <go_mongodb_aws>`
-   * - :ref:`X.509 <go_x509>
-
-
+* :ref:`SCRAM-SHA-256 <go_sha_256>`
+* :ref:`SCRAM-SHA-1 <go_sha_1>`
+* :ref:`MONGODB-CR <go_mongodb_cr>`
+* :ref:`MongoDB-AWS <go_mongodb_aws>`
+* :ref:`X.509 <go_x509>`
 
 The Go Driver establishes a connection with an authentication mechanism
 through a `Client <{+api+}/mongo#Client>`__


### PR DESCRIPTION
## Pull Request Info

This removes the empty tls guide link, and shows the auth options in a list early on in the heading (and links to each one).

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18736

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6143b215c608bec57fe2cee4

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18736/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
