### PR TITLE
DOCSP-13842 crud delete page

### DIFF
--- a/source/fundamentals/crud/write-operations.txt
+++ b/source/fundamentals/crud/write-operations.txt
@@ -5,20 +5,20 @@ Write Operations
 .. default-domain:: mongodb
 
 - :doc:`/fundamentals/crud/write-operations/insert`
+- :doc:`/fundamentals/crud/write-operations/delete`
 - :doc:`/fundamentals/crud/write-operations/change-a-document`
 
 ..
   - :doc:`/fundamentals/crud/write-operations/upsert`
-  - :doc:`/fundamentals/crud/write-operations/delete`
   - :doc:`/fundamentals/crud/write-operations/embedded-arrays`
 
 .. toctree::
    :caption: Write Operations
 
    /fundamentals/crud/write-operations/insert
+   /fundamentals/crud/write-operations/delete
    /fundamentals/crud/write-operations/change-a-document
 
 ..
   /fundamentals/crud/write-operations/upsert
-  /fundamentals/crud/write-operations/delete
   /fundamentals/crud/write-operations/embedded-arrays

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -1,0 +1,116 @@
+=================
+Delete a Document
+=================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _delete_guide_golang:
+
+Overview
+--------
+
+In this guide, you can learn how to remove documents from your MongoDB
+collections.
+
+Sample Data
+~~~~~~~~~~~
+
+To perform the examples in this guide, run the following snippet to load
+the documents into the ``ratings`` collection of the ``tea`` database:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/delete.go
+   :language: go
+   :dedent:
+   :start-after: begin insertDocs
+   :end-before: end insertDocs
+
+Each document contains a rating for a type of tea, which corresponds to
+the ``type`` and ``rating`` fields.
+
+Delete Operations
+-----------------
+
+Use **delete operations** to remove data from MongoDB. Delete operations
+consist of the ``DeleteOne()`` and ``DeleteMany()`` functions.
+
+Delete One Document
+~~~~~~~~~~~~~~~~~~~
+
+The ``DeleteOne()`` function expects you to pass a ``Context`` type and a
+query filter. The function deletes *the first document* that matches the
+filter. 
+
+
+Delete All Documents
+~~~~~~~~~~~~~~~~~~~~
+
+The ``DeleteMany()`` function expects you to pass a ``Context`` type and a
+query filter. The function deletes *all* documents that match the
+filter.
+
+.. tip::
+
+    If one document matches your filter, the ``DeleteMany()`` function
+    is equivalent to the ``DeleteOne`` function.
+
+Both functions optionally take a ``DeleteOptions`` type, which
+represents options you can use to configure the function. 
+
+Both functions also return a ``DeleteResult`` type, which contains the
+number of documents deleted. If there are no matches to your filter, no
+document gets deleted and ``DeleteResult`` returns ``0``.
+
+Example
+```````
+
+The following example passes a context and a filter to the ``DeleteMany()``
+function, which performs the following: 
+
+- Matches documents where the ``ratings`` is greater than ``8``
+- Specifies for the function to not send a hint and to use the default collation
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/delete.go
+   :language: go
+   :dedent:
+   :start-after: begin deleteMany
+   :end-before: end deleteMany
+
+After running the preceding example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+    Number of documents deleted: 2
+
+.. tip::
+
+    If the preceding example used the ``DeleteOne()`` function, the
+    driver deletes the first document matched of the two.
+
+Additional Information
+----------------------
+
+For runnable examples of the delete operations, see the following usage
+examples:
+
+- :doc:`Delete a Document </usage-examples/deleteOne>`
+- :doc:`Delete Multiple Documents </usage-examples/deleteMany>`
+
+.. For more information about collations, see our guide on <TODO: Collations>.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For more information on any of the functions or types discussed in this
+guide, see the following API Documentation:
+
+- `DeleteOne() <{+api+}/mongo#Collection.DeleteOne>`__
+- `DeleteMany() <{+api+}/mongo#Collection.DeleteMany>`__
+- `DeleteOptions <{+api+}/options#DeleteOptions>`__
+- `DeleteResult <{+api+}/mongo#DeleteResult>`__

--- a/source/includes/fundamentals/code-snippets/CRUD/delete.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/delete.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
+		log.Fatal("You must set your `MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("tea").Collection("ratings").Drop(context.TODO())
+
+	// begin insertDocs
+	coll := client.Database("tea").Collection("ratings")
+	docs := []interface{}{
+		bson.D{{"type", "Masala"}, {"rating", 10}},
+		bson.D{{"type", "Earl Grey"}, {"rating", 7}},
+		bson.D{{"type", "Oolong"}, {"rating", 10}},
+		bson.D{{"type", "Assam"}, {"rating", 7}},
+	}
+
+	result, insertErr := coll.InsertMany(context.TODO(), docs)
+	if insertErr != nil {
+		panic(insertErr)
+	}
+	// end insertDocs
+	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+
+	// begin deleteMany
+	deleteManyFilter := bson.D{{"rating", bson.D{{"$gt", 8},}},}
+
+	deleteManyResult, deleteManyErr := coll.DeleteMany(context.TODO(), deleteManyFilter, options.Delete().SetHint(nil).SetCollation(nil),)
+	fmt.Printf("Number of documents deleted: %d\n", deleteManyResult.DeletedCount)
+	// end deleteMany
+	if deleteManyErr != nil {
+		panic(deleteManyErr)
+	}
+}

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -46,6 +46,9 @@ Multiple Documents Usage Example </usage-examples/find>`.
 Additional Information
 ----------------------
 
+For more information on deleting documents, see our guide on
+:ref:`deleting documents <delete_guide_golang>`.
+
 API Documentation
 ~~~~~~~~~~~~~~~~~
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -43,10 +43,8 @@ a Document Usage Example </usage-examples/findOne>`.
 Additional Information
 ----------------------
 
-..
-  For more information on deleting documents, specifying query filters,
-  and handling potential errors, see our guide on <TODO:
-  Deleting a Document>.
+For more information on deleting documents, see our guide on
+:ref:`deleting documents <delete_guide_golang>`.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Added the CRUD > Write Operations > Delete a Document page.
Updated the links in the delete usage examples to route to this new page.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13842

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6153c98d8670bd2731b1c929

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13842-CRUDDelete/fundamentals/crud/write-operations/delete/

https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13842-CRUDDelete/usage-examples/deleteOne/

https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13842-CRUDDelete/usage-examples/deleteMany/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
