### PR TITLE
DOCSP-13835 crud sort

### DIFF
--- a/source/fundamentals/crud/read-operations.txt
+++ b/source/fundamentals/crud/read-operations.txt
@@ -5,10 +5,10 @@ Read Operations
 .. default-domain:: mongodb
 
 - :doc:`/fundamentals/crud/read-operations/retrieve`
+- :doc:`/fundamentals/crud/read-operations/sort`
 
 ..
   - :doc:`/fundamentals/crud/read-operations/cursor`
-  - :doc:`/fundamentals/crud/read-operations/sort`
   - :doc:`/fundamentals/crud/read-operations/limit`
   - :doc:`/fundamentals/crud/read-operations/skip`
   - :doc:`/fundamentals/crud/read-operations/project`
@@ -19,12 +19,11 @@ Read Operations
    :caption: Read Operations
    
    /fundamentals/crud/read-operations/retrieve
+   /fundamentals/crud/read-operations/sort
 ..
   /fundamentals/crud/read-operations/cursor
-  /fundamentals/crud/read-operations/sort
   /fundamentals/crud/read-operations/limit
   /fundamentals/crud/read-operations/skip
   /fundamentals/crud/read-operations/project
   /fundamentals/crud/read-operations/geo
   /fundamentals/crud/read-operations/text
-

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -144,7 +144,7 @@ the MongoDB server manual page on :manual:`Aggregation
 Additional Information
 ----------------------
 
-For runnable examples of the update operations, see the following usage
+For runnable examples of the find operations, see the following usage
 examples:
 
 - :doc:`Find a Document </usage-examples/findOne>`

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -46,7 +46,7 @@ Sort Direction
 --------------
 
 To specify the order of your results, pass an interface specifying the
-field and sort direction to the ``SetSort()`` function of a read
+sort fields and directions to the ``SetSort()`` function of a read
 operations' options.
 
 The options you specify are the last parameter to the following read
@@ -93,11 +93,11 @@ After running the preceding example, the output resembles the following:
    :copyable: false
 
     //results truncated
-    [_id:ObjectID("...") rating:5 type:Assam]
-    [_id:ObjectID("...") rating:5 type:English Breakfast]
-    [_id:ObjectID("...") rating:7 type:Oolong]
-    [_id:ObjectID("...") rating:8 type:Earl Grey]
-    [_id:ObjectID("...") rating:10 type:Masala]
+   [{_id ObjectID("...")} {type Assam} {rating 5}]
+   [{_id ObjectID("...")} {type English Breakfast} {rating 5}]
+   [{_id ObjectID("...")} {type Oolong} {rating 7}]
+   [{_id ObjectID("...")} {type Earl Grey} {rating 8}]
+   [{_id ObjectID("...")} {type Masala} {rating 10}]
 
 Descending
 ~~~~~~~~~~
@@ -130,11 +130,11 @@ After running the preceding example, the output resembles the following:
 .. code-block:: none
    :copyable: false
 
-    [_id:ObjectID("...") rating:10 type:Masala]
-    [_id:ObjectID("...") rating:8 type:Earl Grey]
-    [_id:ObjectID("...") rating:7 type:Oolong]
-    [_id:ObjectID("...") rating:5 type:Assam]
-    [_id:ObjectID("...") rating:5 type:English Breakfast]
+   [{_id ObjectID("...")} {type Masala} {rating 10}]
+   [{_id ObjectID("...")} {type Earl Grey} {rating 8}]
+   [{_id ObjectID("...")} {type Oolong} {rating 7}]
+   [{_id ObjectID("...")} {type Assam} {rating 5}]
+   [{_id ObjectID("...")} {type English Breakfast} {rating 5}]
 
 Handling Ties
 ~~~~~~~~~~~~~
@@ -149,8 +149,8 @@ the following documents:
 .. code-block:: none
    :copyable: false
 
-   [_id:ObjectID("...") rating:5 type:Assam]
-   [_id:ObjectID("...") rating:5 type:English Breakfast]
+   [{_id ObjectID("...")} {type Assam} {rating 5}]
+   [{_id ObjectID("...")} {type English Breakfast} {rating 5}]
 
 To guarantee a specific order for documents when ties occur, specify
 additional fields to sort by.
@@ -173,11 +173,11 @@ After running the preceding example, the output resembles the following:
 .. code-block:: none
    :copyable: false
 
-   [_id:ObjectID("...") rating:5 type:English Breakfast]
-   [_id:ObjectID("...") rating:5 type:Assam]
-   [_id:ObjectID("...") rating:7 type:Oolong]
-   [_id:ObjectID("...") rating:8 type:Earl Grey]
-   [_id:ObjectID("...") rating:10 type:Masala]
+   [{_id ObjectID("...")} {type English Breakfast} {rating 5}]
+   [{_id ObjectID("...")} {type Assam} {rating 5}]
+   [{_id ObjectID("...")} {type Oolong} {rating 7}]
+   [{_id ObjectID("...")} {type Earl Grey} {rating 8}]
+   [{_id ObjectID("...")} {type Masala} {rating 10}]
 
 .. tip:: Using Aggregation 
 
@@ -199,7 +199,7 @@ Additional Information
 For more information on performing read operations, see our guide on
 :doc:`retrieving data </fundamentals/crud/read-operations/retrieve>`.
 
-.. For information about sorting in an aggregation pipeline, see our
+.. For information about sorting text, see our
 .. guide on :doc:`Text Search </fundamentals/crud/write-operations/text>`.
 
 API Documentation

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -215,4 +215,4 @@ guide, see the following API Documentation:
 - `FindOneAndDelete() <{+api+}/mongo#Collection.FindOneAndDelete>`__
 - `FindOneAndUpdate() <{+api+}/mongo#Collection.FindOneAndUpdate>`__
 - `FindOneAndReplace() <{+api+}/mongo#Collection.FindOneAndReplace>`__
-- `gridfs.Bucket.Find() <{+api+}/mongo/gridfs#Bucket.Find`__
+- `gridfs.Bucket.Find() <{+api+}/mongo/gridfs#Bucket.Find>`__

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -29,7 +29,7 @@ snippet:
    :start-after: begin insertDocs
    :end-before: end insertDocs
 
-.. note:: Non-existent Database and Collections
+.. tip:: Non-existent Database and Collections
 
    The driver automatically creates the necessary database and/or collection
    when you perform a write operation against them if they don't already exist.
@@ -46,10 +46,10 @@ Sort Direction
 --------------
 
 To specify the order your results, pass an interface containing the
-field and direction to sort in to the ``FindOptions.SetSort()`` function
+field and sort direction in to the ``FindOptions.SetSort()`` function
 as the third parameter to the ``Find()`` function.
 
-The direction of your sort can be **ascending** or **descending**.
+The sort direction can be **ascending** or **descending**.
 
 Ascending
 ~~~~~~~~~
@@ -60,9 +60,9 @@ specify this sort, pass the field you want to sort by and a ``1`` to the
 
 .. tip::
 
-   A ``Boolean`` orders ``false`` then ``true``, a ``String``
-   orders from **a to z** and numeric types order from **negative
-   infinity to infinity**.
+   With an ascending sort, a ``Boolean`` orders ``false`` **then**
+   ``true``, a ``String`` orders from **a to z** and numeric types order
+   from **negative infinity to positive infinity**.
 
 Example 
 ```````
@@ -74,10 +74,11 @@ The following example specifies an ascending sort on ``rating`` field:
    :dedent:
    :start-after: begin ascending sort
    :end-before: end ascending sort
+   :emphasize-lines: 2-3, 5
 
 After running the preceding example, the output resembles the following:
 
-.. code-block:: go
+.. code-block:: none
    :copyable: false
 
     //results truncated
@@ -96,9 +97,9 @@ specify this sort, pass the field you want to sort by and a ``-1`` to the
 
 .. tip::
 
-   A ``Boolean`` orders ``true`` then ``false``, a ``String``
-   orders from **z to a** and numeric types orders from **infinity to
-   negative infinity**.
+   With a descending sort, a ``Boolean`` orders ``true`` **then**
+   ``false``, a ``String`` orders from **z to a** and numeric types
+   orders from **positive infinity to negative infinity**.
 
 Example
 ```````
@@ -110,10 +111,11 @@ The following example specifies a descending sort on ``rating`` field:
    :dedent:
    :start-after: begin descending sort
    :end-before: end descending sort
+   :emphasize-lines: 2-3, 5
 
 After running the preceding example, the output resembles the following:
 
-.. code-block:: go
+.. code-block:: none
    :copyable: false
 
     [_id:ObjectID("...") rating:10 type:Masala]
@@ -127,21 +129,20 @@ Handling Ties
 
 A tie occurs when two or more documents have identical values in the
 field you are using to order your results. MongoDB does not guarantee
-sort order in the event of ties. 
+order in the event of ties. 
 
-For example, we encounter a tie for the ``rating`` for the following
-documents:
+For example, in the preceding examples, we encounter a tie for the
+``rating`` in the following documents:
 
-.. code-block:: go
+.. code-block:: none
    :copyable: false
-
 
    [_id:ObjectID("...") rating:5 type:Assam]
    [_id:ObjectID("...") rating:5 type:English Breakfast]
 
-To guarantee a specific sort order for documents that have fields with
-identical values, specify additional fields to sort on in the
-event of a tie.
+To guarantee a specific order for documents that have fields with
+identical values, specify additional fields to sort by in the event of a
+tie.
 
 Example
 ```````
@@ -154,10 +155,11 @@ then a descending sort on the ``type`` field:
    :dedent:
    :start-after: begin multi sort
    :end-before: end multi sort
+   :emphasize-lines: 2-3, 5
 
 After running the preceding example, the output resembles the following:
 
-.. code-block:: go
+.. code-block:: none
    :copyable: false
 
    [_id:ObjectID("...") rating:5 type:English Breakfast]
@@ -166,10 +168,10 @@ After running the preceding example, the output resembles the following:
    [_id:ObjectID("...") rating:8 type:Earl Grey]
    [_id:ObjectID("...") rating:10 type:Masala]
 
-.. tip::
+.. tip:: Using Aggregation 
 
-   You can also specify a sort in an aggregation pipeline, include
-   :manual:`$sort </reference/operator/aggregation/sort/>` stage. 
+   You can also specify a sort in an aggregation pipeline by including
+   the :manual:`$sort </reference/operator/aggregation/sort/>` stage.
 
    The following example specifies the same sort from the preceding
    example in an aggregation pipeline:

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -4,11 +4,197 @@ Sort Results
 
 .. default-domain:: mongodb
 
-Use ``sort()`` to change the order in which read operations return
-documents. The ``sort()`` instance method tells MongoDB to order returned documents by the
-values of one or more fields in a certain direction. To sort returned
-documents by a field in ascending (lowest first) order, use the static method ``Sorts.ascending()``,
-specifying the field on which to sort. To sort in descending (greatest first) order instead,
-use the static method ``Sorts.descending()``, specifying the field on which to sort. For example,
-you can sort on ``id`` or ``name`` fields. If you do not specify a sort, MongoDB does not
-guarantee the order of query results.
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to specify the order of your results
+from read operations.
+
+Sample Data
+~~~~~~~~~~~
+
+To run the examples in this guide, load these documents into the
+``ratings`` collection of the ``tea`` database with the following
+snippet:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
+   :language: go
+   :dedent:
+   :start-after: begin insertDocs
+   :end-before: end insertDocs
+
+.. note:: Non-existent Database and Collections
+
+   The driver automatically creates the necessary database and/or collection
+   when you perform a write operation against them if they don't already exist.
+
+Each document contains a rating for a type of tea, which corresponds to
+the ``type`` and ``rating`` fields.
+
+.. note::
+
+   Each example truncates the ``ObjectID`` value since the driver
+   generates them uniquely.
+
+Sort Direction
+--------------
+
+To specify the order your results, pass an interface containing the
+field and direction to sort in to the ``FindOptions.SetSort()`` function
+as the third parameter to the ``Find()`` function.
+
+The direction of your sort can be **ascending** or **descending**.
+
+Ascending
+~~~~~~~~~
+
+An ascending sort orders your results from smallest to largest. To
+specify this sort, pass the field you want to sort by and a ``1`` to the
+``FindOptions.SetSort()`` function.
+
+.. tip::
+
+   A ``Boolean`` orders ``false`` then ``true``, a ``String``
+   orders from **a to z** and numeric types order from **negative
+   infinity to infinity**.
+
+Example 
+```````
+
+The following example specifies an ascending sort on ``rating`` field:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
+   :language: go
+   :dedent:
+   :start-after: begin ascending sort
+   :end-before: end ascending sort
+
+After running the preceding example, the output resembles the following:
+
+.. code-block:: go
+   :copyable: false
+
+    //results truncated
+    [_id:ObjectID("...") rating:5 type:Assam]
+    [_id:ObjectID("...") rating:5 type:English Breakfast]
+    [_id:ObjectID("...") rating:7 type:Oolong]
+    [_id:ObjectID("...") rating:8 type:Earl Grey]
+    [_id:ObjectID("...") rating:10 type:Masala]
+
+Descending
+~~~~~~~~~~
+
+A descending sort orders your results from largest to smallest. To
+specify this sort, pass the field you want to sort by and a ``-1`` to the
+``FindOptions.SetSort()`` function.
+
+.. tip::
+
+   A ``Boolean`` orders ``true`` then ``false``, a ``String``
+   orders from **z to a** and numeric types orders from **infinity to
+   negative infinity**.
+
+Example
+```````
+
+The following example specifies a descending sort on ``rating`` field:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
+   :language: go
+   :dedent:
+   :start-after: begin descending sort
+   :end-before: end descending sort
+
+After running the preceding example, the output resembles the following:
+
+.. code-block:: go
+   :copyable: false
+
+    [_id:ObjectID("...") rating:10 type:Masala]
+    [_id:ObjectID("...") rating:8 type:Earl Grey]
+    [_id:ObjectID("...") rating:7 type:Oolong]
+    [_id:ObjectID("...") rating:5 type:Assam]
+    [_id:ObjectID("...") rating:5 type:English Breakfast]
+
+Handling Ties
+~~~~~~~~~~~~~
+
+A tie occurs when two or more documents have identical values in the
+field you are using to order your results. MongoDB does not guarantee
+sort order in the event of ties. 
+
+For example, we encounter a tie for the ``rating`` for the following
+documents:
+
+.. code-block:: go
+   :copyable: false
+
+
+   [_id:ObjectID("...") rating:5 type:Assam]
+   [_id:ObjectID("...") rating:5 type:English Breakfast]
+
+To guarantee a specific sort order for documents that have fields with
+identical values, specify additional fields to sort on in the
+event of a tie.
+
+Example
+```````
+
+The following example specifies an ascending sort on ``rating`` field,
+then a descending sort on the ``type`` field:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
+   :language: go
+   :dedent:
+   :start-after: begin multi sort
+   :end-before: end multi sort
+
+After running the preceding example, the output resembles the following:
+
+.. code-block:: go
+   :copyable: false
+
+   [_id:ObjectID("...") rating:5 type:English Breakfast]
+   [_id:ObjectID("...") rating:5 type:Assam]
+   [_id:ObjectID("...") rating:7 type:Oolong]
+   [_id:ObjectID("...") rating:8 type:Earl Grey]
+   [_id:ObjectID("...") rating:10 type:Masala]
+
+.. tip::
+
+   You can also specify a sort in an aggregation pipeline, include
+   :manual:`$sort </reference/operator/aggregation/sort/>` stage. 
+
+   The following example specifies the same sort from the preceding
+   example in an aggregation pipeline:
+
+   .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
+      :language: go
+      :dedent:
+      :start-after: begin aggregate sort
+      :end-before: end aggregate sort
+
+Additional Information
+----------------------
+
+For more information on how to perform read operations, see our guide on
+:doc:`retrieving data </fundamentals/crud/read-operations/retrieve>`.
+
+.. For information on how to sort using an aggregation pipeline, see our
+.. guide on :doc:`Text Search </fundamentals/crud/write-operations/text>`.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For more information on any of the functions or types discussed in this
+guide, see the following API Documentation:
+
+- `Find() <{+api+}/mongo#Collection.Find>`__
+- `FindOptions.SetSort() <{+api+}/mongo/options#FindOptions.SetSort>`__
+- `Aggregate() <{+api+}/mongo#Collection.Aggregate>`__

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -45,8 +45,8 @@ the ``type`` and ``rating`` fields.
 Sort Direction
 --------------
 
-To specify the order your results, pass an interface containing the
-field and sort direction in to the ``FindOptions.SetSort()`` function
+To specify the order of your results, pass an interface specifying the
+field and sort direction to the ``FindOptions.SetSort()`` function
 as the third parameter to the ``Find()`` function.
 
 The sort direction can be **ascending** or **descending**.
@@ -55,19 +55,20 @@ Ascending
 ~~~~~~~~~
 
 An ascending sort orders your results from smallest to largest. To
-specify this sort, pass the field you want to sort by and a ``1`` to the
+specify this sort, pass the field you want to sort by and ``1`` to the
 ``FindOptions.SetSort()`` function.
 
 .. tip::
 
-   With an ascending sort, a ``Boolean`` orders ``false`` **then**
-   ``true``, a ``String`` orders from **a to z** and numeric types order
-   from **negative infinity to positive infinity**.
+   With an ascending sort, the function orders values of type
+   ``Boolean`` from ``false`` *to* ``true``, ``String`` type values
+   from *a to z* and numeric type values from *negative infinity to
+   positive infinity*.
 
 Example 
 ```````
 
-The following example specifies an ascending sort on ``rating`` field:
+The following example specifies an ascending sort on the ``rating`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
    :language: go
@@ -92,19 +93,20 @@ Descending
 ~~~~~~~~~~
 
 A descending sort orders your results from largest to smallest. To
-specify this sort, pass the field you want to sort by and a ``-1`` to the
+specify this sort, pass the field you want to sort by and ``-1`` to the
 ``FindOptions.SetSort()`` function.
 
 .. tip::
 
-   With a descending sort, a ``Boolean`` orders ``true`` **then**
-   ``false``, a ``String`` orders from **z to a** and numeric types
-   orders from **positive infinity to negative infinity**.
+   With an descending sort, the function orders values of type
+   ``Boolean`` from ``true`` *to* ``false``, ``String`` type values
+   from *z to a* and numeric type values from *positive infinity to
+   negative infinity*.
 
 Example
 ```````
 
-The following example specifies a descending sort on ``rating`` field:
+The following example specifies a descending sort on the ``rating`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
    :language: go
@@ -128,11 +130,11 @@ Handling Ties
 ~~~~~~~~~~~~~
 
 A tie occurs when two or more documents have identical values in the
-field you are using to order your results. MongoDB does not guarantee
-order in the event of ties. 
+field you are using to sort your results. MongoDB does not guarantee
+order if ties occur. 
 
-For example, in the preceding examples, we encounter a tie for the
-``rating`` in the following documents:
+For example, in the sample data, there is a tie for the ``rating`` in
+the following documents:
 
 .. code-block:: none
    :copyable: false
@@ -140,14 +142,13 @@ For example, in the preceding examples, we encounter a tie for the
    [_id:ObjectID("...") rating:5 type:Assam]
    [_id:ObjectID("...") rating:5 type:English Breakfast]
 
-To guarantee a specific order for documents that have fields with
-identical values, specify additional fields to sort by in the event of a
-tie.
+To guarantee a specific order for documents when ties occur, specify
+additional fields to sort by.
 
 Example
 ```````
 
-The following example specifies an ascending sort on ``rating`` field,
+The following example specifies an ascending sort on the ``rating`` field,
 then a descending sort on the ``type`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
@@ -185,10 +186,10 @@ After running the preceding example, the output resembles the following:
 Additional Information
 ----------------------
 
-For more information on how to perform read operations, see our guide on
+For more information on performing read operations, see our guide on
 :doc:`retrieving data </fundamentals/crud/read-operations/retrieve>`.
 
-.. For information on how to sort using an aggregation pipeline, see our
+.. For information about sorting in an aggregation pipeline, see our
 .. guide on :doc:`Text Search </fundamentals/crud/write-operations/text>`.
 
 API Documentation

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -46,8 +46,18 @@ Sort Direction
 --------------
 
 To specify the order of your results, pass an interface specifying the
-field and sort direction to the ``FindOptions.SetSort()`` function
-as the third parameter to the ``Find()`` function.
+field and sort direction to the ``SetSort()`` function of a read
+operations' options.
+
+The options you specify are the last parameter to the following read
+operation functions:
+
+- ``Find()``
+- ``FindOne()``
+- ``FindOneAndDelete()``
+- ``FindOneAndUpdate()``
+- ``FindOneAndReplace()``
+- ``gridfs.Bucket.Find()``
 
 The sort direction can be **ascending** or **descending**.
 
@@ -56,7 +66,7 @@ Ascending
 
 An ascending sort orders your results from smallest to largest. To
 specify this sort, pass the field you want to sort by and ``1`` to the
-``FindOptions.SetSort()`` function.
+``SetSort()`` function.
 
 .. tip::
 
@@ -94,7 +104,7 @@ Descending
 
 A descending sort orders your results from largest to smallest. To
 specify this sort, pass the field you want to sort by and ``-1`` to the
-``FindOptions.SetSort()`` function.
+``SetSort()`` function.
 
 .. tip::
 
@@ -201,3 +211,8 @@ guide, see the following API Documentation:
 - `Find() <{+api+}/mongo#Collection.Find>`__
 - `FindOptions.SetSort() <{+api+}/mongo/options#FindOptions.SetSort>`__
 - `Aggregate() <{+api+}/mongo#Collection.Aggregate>`__
+- `FindOne() <{+api+}/mongo#Collection.FindOne>`__
+- `FindOneAndDelete() <{+api+}/mongo#Collection.FindOneAndDelete>`__
+- `FindOneAndUpdate() <{+api+}/mongo#Collection.FindOneAndUpdate>`__
+- `FindOneAndReplace() <{+api+}/mongo#Collection.FindOneAndReplace>`__
+- `gridfs.Bucket.Find() <{+api+}/mongo/gridfs#Bucket.Find`__

--- a/source/includes/fundamentals/code-snippets/CRUD/sort.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/sort.go
@@ -100,13 +100,9 @@ func main() {
 
 	fmt.Println("Aggegation Sort:")
 	// begin aggregate sort
-	groupStage := bson.D{
-		{"$sort", bson.D{
-			{"rating", 1},
-			{"type", -1},
-		}}}
+	sortStage := bson.D{{"$sort", bson.D{{"rating", 1}, {"type", -1}}}}
 
-	aggCursor, aggErr := coll.Aggregate(context.TODO(), mongo.Pipeline{groupStage})
+	aggCursor, aggErr := coll.Aggregate(context.TODO(), mongo.Pipeline{sortStage})
 	if aggErr != nil {
 		panic(aggErr)
 	}

--- a/source/includes/fundamentals/code-snippets/CRUD/sort.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/sort.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
+		log.Fatal("You must set your `MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("tea").Collection("ratings").Drop(context.TODO())
+
+	// begin insertDocs
+	coll := client.Database("tea").Collection("ratings")
+	docs := []interface{}{
+		bson.D{{"type", "Masala"}, {"rating", 10}},
+		bson.D{{"type", "Assam"}, {"rating", 5}},
+		bson.D{{"type", "Oolong"}, {"rating", 7}},
+		bson.D{{"type", "Earl Grey"}, {"rating", 8}},
+		bson.D{{"type", "English Breakfast"}, {"rating", 5}},
+	}
+
+	result, insertErr := coll.InsertMany(context.TODO(), docs)
+	if insertErr != nil {
+		panic(insertErr)
+	}
+	//end insertDocs
+	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+
+	fmt.Println("Ascending Sort:")
+	//begin ascending sort
+	ascendingFilter := bson.D{{}}
+	acendingSort := bson.D{{"rating", 1}}
+	ascendingOptions := options.Find().SetSort(acendingSort)
+
+	ascendingCursor, ascendingErr := coll.Find(context.TODO(), ascendingFilter, ascendingOptions)
+
+	var ascendingResults []bson.M
+	if ascendingErr = ascendingCursor.All(context.TODO(), &ascendingResults); ascendingErr != nil {
+		panic(ascendingErr)
+	}
+	for _, result := range ascendingResults {
+		fmt.Println(result)
+	}
+	//end ascending sort
+
+	fmt.Println("Descending Sort:")
+	//begin descending sort
+	descendingFilter := bson.D{{}}
+	descendingSort := bson.D{{"rating", -1}}
+	descendingOptions := options.Find().SetSort(descendingSort)
+
+	descendingCursor, descendingErr := coll.Find(context.TODO(), descendingFilter, descendingOptions)
+
+	var descendingResults []bson.M
+	if descendingErr = descendingCursor.All(context.TODO(), &descendingResults); descendingErr != nil {
+		panic(descendingErr)
+	}
+	for _, result := range descendingResults {
+		fmt.Println(result)
+	}
+	//end descending sort
+
+	fmt.Println("Multi Sort:")
+	//begin multi sort
+	findFilter := bson.D{{}}
+	sort := bson.D{{"rating", 1}, {"type", -1}}
+	findOptions := options.Find().SetSort(sort)
+
+	findCursor, findErr := coll.Find(context.TODO(), findFilter, findOptions)
+
+	var findResults []bson.M
+	if findErr = findCursor.All(context.TODO(), &findResults); findErr != nil {
+		panic(findErr)
+	}
+	for _, result := range findResults {
+		fmt.Println(result)
+	}
+	//end multi sort
+
+	fmt.Println("Aggegation Sort:")
+	// begin aggregate sort
+	groupStage := bson.D{
+		{"$sort", bson.D{
+			{"rating", 1},
+			{"type", -1},
+		}}}
+
+	aggCursor, aggErr := coll.Aggregate(context.TODO(), mongo.Pipeline{groupStage})
+	if aggErr != nil {
+		panic(aggErr)
+	}
+
+	var aggResults []bson.M
+	if aggErr = aggCursor.All(context.TODO(), &aggResults); aggErr != nil {
+		panic(aggErr)
+	}
+	for _, result := range aggResults {
+		fmt.Println(result)
+	}
+	// end aggregate sort
+}

--- a/source/includes/fundamentals/code-snippets/CRUD/sort.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/sort.go
@@ -13,8 +13,8 @@ import (
 
 func main() {
 	var uri string
-	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
-		log.Fatal("You must set your `MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
+		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
@@ -49,13 +49,13 @@ func main() {
 
 	fmt.Println("Ascending Sort:")
 	//begin ascending sort
-	ascendingFilter := bson.D{{}}
+	ascendingFilter := bson.D{}
 	acendingSort := bson.D{{"rating", 1}}
 	ascendingOptions := options.Find().SetSort(acendingSort)
 
 	ascendingCursor, ascendingErr := coll.Find(context.TODO(), ascendingFilter, ascendingOptions)
 
-	var ascendingResults []bson.M
+	var ascendingResults []bson.D
 	if ascendingErr = ascendingCursor.All(context.TODO(), &ascendingResults); ascendingErr != nil {
 		panic(ascendingErr)
 	}
@@ -66,13 +66,13 @@ func main() {
 
 	fmt.Println("Descending Sort:")
 	//begin descending sort
-	descendingFilter := bson.D{{}}
+	descendingFilter := bson.D{}
 	descendingSort := bson.D{{"rating", -1}}
 	descendingOptions := options.Find().SetSort(descendingSort)
 
 	descendingCursor, descendingErr := coll.Find(context.TODO(), descendingFilter, descendingOptions)
 
-	var descendingResults []bson.M
+	var descendingResults []bson.D
 	if descendingErr = descendingCursor.All(context.TODO(), &descendingResults); descendingErr != nil {
 		panic(descendingErr)
 	}
@@ -83,13 +83,13 @@ func main() {
 
 	fmt.Println("Multi Sort:")
 	//begin multi sort
-	findFilter := bson.D{{}}
+	findFilter := bson.D{}
 	sort := bson.D{{"rating", 1}, {"type", -1}}
 	findOptions := options.Find().SetSort(sort)
 
 	findCursor, findErr := coll.Find(context.TODO(), findFilter, findOptions)
 
-	var findResults []bson.M
+	var findResults []bson.D
 	if findErr = findCursor.All(context.TODO(), &findResults); findErr != nil {
 		panic(findErr)
 	}
@@ -98,7 +98,7 @@ func main() {
 	}
 	//end multi sort
 
-	fmt.Println("Aggegation Sort:")
+	fmt.Println("Aggregation Sort:")
 	// begin aggregate sort
 	sortStage := bson.D{{"$sort", bson.D{{"rating", 1}, {"type", -1}}}}
 
@@ -107,7 +107,7 @@ func main() {
 		panic(aggErr)
 	}
 
-	var aggResults []bson.M
+	var aggResults []bson.D
 	if aggErr = aggCursor.All(context.TODO(), &aggResults); aggErr != nil {
 		panic(aggErr)
 	}


### PR DESCRIPTION
## Pull Request Info

Added the CRUD > Read Operations > Sort page.

I decided to leave out text search on this page because I think it would be better saved for the Text Search page.

Note: I found and fixed a typo in the retrieve page.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13835

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=615cb0298670bd2731edb18b

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13835-CRUDSort/fundamentals/crud/read-operations/sort/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
