### PR TITLE
DOCSP-13837 crud skip

### DIFF
--- a/source/fundamentals/crud/read-operations.txt
+++ b/source/fundamentals/crud/read-operations.txt
@@ -5,12 +5,12 @@ Read Operations
 .. default-domain:: mongodb
 
 - :doc:`/fundamentals/crud/read-operations/retrieve`
+- :doc:`/fundamentals/crud/read-operations/skip`
 
 ..
   - :doc:`/fundamentals/crud/read-operations/cursor`
   - :doc:`/fundamentals/crud/read-operations/sort`
   - :doc:`/fundamentals/crud/read-operations/limit`
-  - :doc:`/fundamentals/crud/read-operations/skip`
   - :doc:`/fundamentals/crud/read-operations/project`
   - :doc:`/fundamentals/crud/read-operations/geo`
   - :doc:`/fundamentals/crud/read-operations/text`
@@ -19,11 +19,11 @@ Read Operations
    :caption: Read Operations
    
    /fundamentals/crud/read-operations/retrieve
+   /fundamentals/crud/read-operations/skip
 ..
   /fundamentals/crud/read-operations/cursor
   /fundamentals/crud/read-operations/sort
   /fundamentals/crud/read-operations/limit
-  /fundamentals/crud/read-operations/skip
   /fundamentals/crud/read-operations/project
   /fundamentals/crud/read-operations/geo
   /fundamentals/crud/read-operations/text

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -28,7 +28,7 @@ collection of the ``tea`` database:
    :start-after: begin insertDocs
    :end-before: end insertDocs
 
-..literalinclude:: /includes/fundamentals/code-snippets/tea-sample-data-ending.rst
+..include:: /includes/fundamentals/code-snippets/tea-sample-data-ending.rst
 
 Skip
 ----
@@ -92,7 +92,8 @@ Additional Information
 For more information on performing read operations, see our guide on
 :doc:`retrieving data </fundamentals/crud/read-operations/retrieve>`.
 
-.. For information about sorting, see our guide on :doc:`Sort Results </fundamentals/read-operations/sort>`.
+For information about sorting, see our guide on :doc:`Sort Results
+</fundamentals/crud/read-operations/sort>`. 
 
 API Documentation
 ~~~~~~~~~~~~~~~~~
@@ -104,4 +105,4 @@ guide, see the following API Documentation:
 - `FindOptions.SetSkip() <{+api+}/mongo/options#FindOptions.SetSkip>`__
 - `Aggregate() <{+api+}/mongo#Collection.Aggregate>`__
 - `CountDocuments() <{+api+}/mongo#Collection.CountDocuments>`__
-- `gridfs.Bucket.Find() <{+api+}/mongo/gridfs#Bucket.Find`__
+- `gridfs.Bucket.Find() <{+api+}/mongo/gridfs#Bucket.Find>`__

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -1,0 +1,107 @@
+=====================
+Skip Returned Results
+=====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to skip a specified number of returned
+results from read operations. 
+
+Sample Data
+~~~~~~~~~~~
+
+Run the following snippet to load the documents into the ``ratings``
+collection of the ``tea`` database:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/skip.go
+   :language: go
+   :dedent:
+   :start-after: begin insertDocs
+   :end-before: end insertDocs
+
+..literalinclude:: /includes/fundamentals/code-snippets/tea-sample-data-ending.rst
+
+Skip
+----
+
+To skip a specified number of returned results from a query, pass the
+number of documents you want to skip to the ``SetSkip()`` function of
+the read operations' options.
+
+The options you specify are the last parameter to the following read
+operation functions:
+
+- ``Find()``
+- ``FindOne()``
+- ``CountDocuments()``
+- ``gridfs.Bucket.Find()``
+
+If the number of documents exceeds the number of matched documents for a
+query, that query returns no documents.
+
+.. tip::
+
+    Passing in a negative number to the ``SetSkip()`` function results
+    in a runtime error.
+
+The is no guarantee in the order of returned documents. You should
+use ``SetSort()`` function before the ``SetSkip()`` function to avoid
+skipping random documents.
+
+Example
+~~~~~~~
+
+The following example performs the following in order with the
+``Find()`` function:
+
+- Sorts all the matched documents in ascending order
+- Skips the first two documents
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/skip.go
+   :language: go
+   :dedent:
+   :start-after: begin skip
+   :end-before: end skip
+
+.. tip:: Using Aggregation 
+
+   You can also specify a skip in an aggregation pipeline by including
+   the :manual:`$skip </reference/operator/aggregation/skip/>` stage.
+
+   The following example specifies the same sort and skip from the
+   preceding example in an aggregation pipeline:
+
+   .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/skip.go
+      :language: go
+      :dedent:
+      :start-after: begin aggregate skip
+      :end-before: end aggregate skip
+
+Additional Information
+----------------------
+
+For more information on performing read operations, see our guide on
+:doc:`retrieving data </fundamentals/crud/read-operations/retrieve>`.
+
+.. For information about sorting, see our guide on :doc:`Sort Results </fundamentals/read-operations/sort>`.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For more information on any of the functions or types discussed in this
+guide, see the following API Documentation:
+
+- `Find() <{+api+}/mongo#Collection.Find>`__
+- `FindOptions.SetSkip() <{+api+}/mongo/options#FindOptions.SetSkip>`__
+- `Aggregate() <{+api+}/mongo#Collection.Aggregate>`__
+- `CountDocuments() <{+api+}/mongo#Collection.CountDocuments>`__
+- `gridfs.Bucket.Find() <{+api+}/mongo/gridfs#Bucket.Find`__

--- a/source/includes/fundamentals/code-snippets/CRUD/skip.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/skip.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
+		log.Fatal("You must set your `MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("tea").Collection("ratings").Drop(context.TODO())
+
+	// begin insertDocs
+	coll := client.Database("tea").Collection("ratings")
+	docs := []interface{}{
+		bson.D{{"type", "Masala"}, {"rating", 10}},
+		bson.D{{"type", "Assam"}, {"rating", 5}},
+		bson.D{{"type", "Oolong"}, {"rating", 7}},
+		bson.D{{"type", "Earl Grey"}, {"rating", 8}},
+		bson.D{{"type", "English Breakfast"}, {"rating", 5}},
+	}
+
+	result, insertErr := coll.InsertMany(context.TODO(), docs)
+	if insertErr != nil {
+		panic(insertErr)
+	}
+	//end insertDocs
+	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+
+	fmt.Println("Skip:")
+	//begin skip
+	skipFilter := bson.D{{}}
+	skipOptions := options.Find().SetSort(bson.D{{"rating", 1}}).SetSkip(2)
+
+	skipCursor, skipErr := coll.Find(context.TODO(), skipFilter, skipOptions)
+
+	var skipResults []bson.M
+	if skipErr = skipCursor.All(context.TODO(), &skipResults); skipErr != nil {
+		panic(skipErr)
+	}
+	for _, result := range skipResults {
+		fmt.Println(result)
+	}
+	//end skip
+
+	fmt.Println("Aggegation Skip:")
+	// begin aggregate skip
+	sortStage := bson.D{{"$sort", bson.D{{"rating", 1}}}}
+	skipStage := bson.D{{"$skip", 2}}
+
+	aggCursor, aggErr := coll.Aggregate(context.TODO(), mongo.Pipeline{sortStage, skipStage})
+	if aggErr != nil {
+		panic(aggErr)
+	}
+
+	var aggResults []bson.M
+	if aggErr = aggCursor.All(context.TODO(), &aggResults); aggErr != nil {
+		panic(aggErr)
+	}
+	for _, result := range aggResults {
+		fmt.Println(result)
+	}
+	// end aggregate skip
+}

--- a/source/includes/fundamentals/tea-sample-data-ending.rst
+++ b/source/includes/fundamentals/tea-sample-data-ending.rst
@@ -1,0 +1,13 @@
+.. tip:: Non-existent Database and Collections
+
+   The driver automatically creates the necessary database and/or collection
+   when you perform a write operation against them if they don't already exist.
+
+Each document contains a rating for a type of tea, which corresponds to
+the ``type`` and ``rating`` fields.
+
+.. note::
+
+   Each example truncates the ``ObjectID`` value since the driver
+   generates them uniquely.
+   


### PR DESCRIPTION
## Pull Request Info

Added the CRUD > Read Operations Skip page.

Note: The CRUD Sort link at the bottom currently doesn't render as expected because it's also in review. I will make sure to merge in the Sort PR before this one.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13837

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=615ca0428670bd2731e7b5d9

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13837-CRUDSkip/fundamentals/crud/read-operations/skip/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
