### PR TITLE
DOCSP-18987 common find options

### DIFF
--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -66,10 +66,10 @@ To learn how to access data in a ``SingleResult`` see the :ref:`BSON
 Modify Behavior
 ~~~~~~~~~~~~~~~
 
-The ``Find()`` and ``FindOne()`` functions optionally take a
-``FindOptions`` and ``FindOneOptions`` type, which represents options
-you can use to modify their behavior. If you don't specify any options,
-the driver uses the default values for each option.
+You can modify the behavior of ``Find()`` and ``FindOne()`` by passing
+in a``FindOptions`` and ``FindOneOptions`` type respectively. If you
+don't specify any options, the driver uses the default values for each
+option.
 
 You can configure the commonly used options in both types with the
 following functions:
@@ -92,7 +92,7 @@ following functions:
        .. note::
 
           This option is not available for ``FindOneOptions``. The
-          ``FindOne()`` funciton internally uses ``SetLimit(-1)``.
+          ``FindOne()`` function internally uses ``SetLimit(-1)``.
 
    * - ``SetProjection()`` 
      - | The fields to include in the returned documents. 
@@ -103,15 +103,17 @@ following functions:
        | Default: ``0``
 
    * - ``SetSort()`` 
-     - | The order in which to return matching documents
+     - | The field and type of sort to order the matched documents. You can specify an ascending or descending sort.
        | Default: to not specify a sort
 
 Example
 ```````
 
-The following example passes a context and a filter to the ``Find()``
-function, which matches documents where the ``ratings`` field falls
-between ``5`` and ``10``:
+The following example passes a context, filter, and ``FindOptions`` to
+the ``Find()`` function, which performs the following actions:
+
+- Matches documents where the ``rating`` falls between ``5`` and ``10``
+- Returns the ``type`` and ``rating``, but excludes the ``_id`` 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/retrieve.go
    :language: go
@@ -124,9 +126,31 @@ After running the preceding example, the output resembles the following:
 .. code-block:: none
    :copyable: false
 
-    //results truncated
-   [_id:ObjectID("...") type:Masala rating:7 ]
-   [_id:ObjectID("...") type:Earl Grey rating:9 ]
+   [{type Masala} {rating 7}]
+   [{type Earl Grey} {rating 9}]
+
+Example
+```````
+
+The following example passes a context, filter, and ``FindOneOptions``
+to the ``FindOne()`` function, which performs the following actions:
+
+- Matches all documents
+- A descending sort on the ``rating`` field
+- Returns the ``type`` and ``rating``, but excludes the ``_id`` 
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/retrieve.go
+   :language: go
+   :dedent:
+   :start-after: begin find one docs
+   :end-before: end find one docs
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{type Masala} {rating 10}]
 
 .. _retrieve-aggregation:
 
@@ -187,11 +211,11 @@ following functions:
        | Default: ``nil``
 
    * - ``SetMaxTime()`` 
-     - | The maximum amount of time to allow the query to run.
+     - | The maximum amount of time in milliseconds to allow the query to run.
        | Default: ``nil``
 
    * - ``SetMaxAwaitTime()`` 
-     - | The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query.
+     - | The maximum amount of time in milliseconds for the server to wait on new documents to satisfy a tailable cursor query.
        | Default: ``nil``
 
    * - ``SetComment()`` 
@@ -209,7 +233,8 @@ following functions:
 Example
 ```````
 
-The following example passes a context and an aggregation pipeline that:
+The following example passes a context and an aggregation pipeline that
+performs the following actions:
 
 - Groups reviews by types
 - Calculates the average rating of each type
@@ -241,7 +266,7 @@ examples:
 - :doc:`Find a Document </usage-examples/findOne>`
 - :doc:`Find Multiple Documents </usage-examples/find>`
 
-For more infomration about the read operations mentioned, see the
+For more information about the read operations mentioned, see the
 following guides:
 
 - :doc:`Skip Returned Results </fundamentals/crud/read-operations/skip>`

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -63,6 +63,54 @@ filter as a ``SingleResult`` type.
 To learn how to access data in a ``SingleResult`` see the :ref:`BSON
 <bson-unmarshalling>` guide.
 
+Modify Behavior
+~~~~~~~~~~~~~~~
+
+The ``Find()`` and ``FindOne()`` functions optionally take a
+``FindOptions`` and ``FindOneOptions`` type, which represents options
+you can use to modify their Behavior. If you don't specify any options,
+the driver uses the default values for each option.
+
+The following table lists commonly used options in both types:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetCollation()`` 
+     - | The type of language collation to use when sorting results.  
+       | Default: ``nil``
+
+   * - ``SetLimit()`` 
+     - | The maximum number of documents to return. 
+       | Default: ``0`` 
+
+       .. note::
+     
+          This option is not available for ``FindOneOptions``. The
+          ``FindOne()`` internally uses ``SetLimit(-1).
+
+   * - ``SetProjection()`` 
+     - | The fields to include in the returned documents. 
+       | Default: ``nil``
+
+   * - ``SetSkip()`` 
+     - | The number of documents to skip.
+       | Default: ``0``
+
+   * - ``SetSort()`` 
+     - | The order in which to return matching documents
+       | Default: to not specify a sort
+
+For a full list of ``FindOptions`` and ``FindOneOptions``, see the
+following API documentation:
+
+- `FindOptions <{+api+}/mongo/options#FindOptions>`__
+- `FindOneOptions <{+api+}/mongo/options#FindOneOptions>`__
+
 Example
 ```````
 
@@ -144,11 +192,17 @@ examples:
 - :doc:`Find a Document </usage-examples/findOne>`
 - :doc:`Find Multiple Documents </usage-examples/find>`
 
-.. For more information on how to specify a query, see the :doc:`Specify
-.. a Query </fundamentals/crud/query-document>` guide.
+For more infomration about the mentioned read operations, see the
+following guides:
 
-.. For more information on aggregation, see the
-.. :doc:`Aggregation </fundamentals/aggregation>` guide.
+- :doc:`Skip Returned Results </fundamentals/crud/read-operations/skip>`
+- :doc:`Sort Results </fundamentals/crud/read-operations/sort>`
+- :doc:`Limit the Number of Returned Results </fundamentals/crud/read-operations/limit>`
+
+.. - :doc:`Specify Which Fields to Return </fundamentals/crud/read-operations/project>`
+.. - :doc:`Collations </fundamentals/collations>`
+.. - :doc:`Specify a Query </fundamentals/crud/query-document>` guide.
+.. - :doc:`Aggregation </fundamentals/aggregation>` guide.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -67,7 +67,7 @@ Modify Behavior
 ~~~~~~~~~~~~~~~
 
 You can modify the behavior of ``Find()`` and ``FindOne()`` by passing
-in a``FindOptions`` and ``FindOneOptions`` type respectively. If you
+in a ``FindOptions`` and ``FindOneOptions`` type respectively. If you
 don't specify any options, the driver uses the default values for each
 option.
 
@@ -104,7 +104,7 @@ following functions:
 
    * - ``SetSort()`` 
      - | The field and type of sort to order the matched documents. You can specify an ascending or descending sort.
-       | Default: to not specify a sort
+       | Default: none
 
 Example
 ```````
@@ -200,7 +200,7 @@ following functions:
 
    * - ``SetBatchSize()`` 
      - | The number of documents to return in each batch.  
-       | Default: to not specify a value
+       | Default: none
 
    * - ``SetBypassDocumentValidation()`` 
      - | Whether to allow the write to opt-out of document level validation.
@@ -228,7 +228,7 @@ following functions:
 
    * - ``SetLet()`` 
      - | Specifies parameters for the aggregate expression, which improves command readability by separating the variables from the query text.
-       | Default: to not specify parameters
+       | Default: none
 
 Example
 ```````

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -68,10 +68,11 @@ Modify Behavior
 
 The ``Find()`` and ``FindOne()`` functions optionally take a
 ``FindOptions`` and ``FindOneOptions`` type, which represents options
-you can use to modify their Behavior. If you don't specify any options,
+you can use to modify their behavior. If you don't specify any options,
 the driver uses the default values for each option.
 
-The following table lists commonly used options in both types:
+The following table lists the functions to configure the commonly used
+options in both types:
 
 .. list-table::
    :widths: 30 70
@@ -89,9 +90,9 @@ The following table lists commonly used options in both types:
        | Default: ``0`` 
 
        .. note::
-     
+
           This option is not available for ``FindOneOptions``. The
-          ``FindOne()`` internally uses ``SetLimit(-1).
+          ``FindOne()`` funciton internally uses ``SetLimit(-1)``.
 
    * - ``SetProjection()`` 
      - | The fields to include in the returned documents. 
@@ -104,12 +105,6 @@ The following table lists commonly used options in both types:
    * - ``SetSort()`` 
      - | The order in which to return matching documents
        | Default: to not specify a sort
-
-For a full list of ``FindOptions`` and ``FindOneOptions``, see the
-following API documentation:
-
-- `FindOptions <{+api+}/mongo/options#FindOptions>`__
-- `FindOneOptions <{+api+}/mongo/options#FindOneOptions>`__
 
 Example
 ```````
@@ -156,6 +151,60 @@ stage, the pipeline proceeds using all documents in the collection.
 
 .. To learn how to access data in a cursor, see the :doc:`Cursor
 .. </fundamentals/crud/read-operations/cursor>` guide.
+
+Modify Behavior
+~~~~~~~~~~~~~~~
+
+The ``Aggregate()`` function optionally takes an ``AggregateOptions``
+type, which represents options you can use to modify its behavior. If
+you don't specify any options, the driver uses the default values for
+each option.
+
+The following table lists the functions to configure the commonly used
+options in both types:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetAllowDiskUse()`` 
+     - | Whether to write to temporary files.
+       | Default: ``false``
+
+   * - ``SetBatchSize()`` 
+     - | The number of documents to return in each batch.  
+       | Default: to not specify a value
+
+   * - ``SetBypassDocumentValidation()`` 
+     - | Whether to allow the write to opt-out of document level validation.
+       | Default: ``false``
+
+   * - ``SetCollation()`` 
+     - | The type of language collation to use when sorting results.  
+       | Default: ``nil``
+
+   * - ``SetMaxTime()`` 
+     - | The maximum amount of time to allow the query to run.
+       | Default: ``nil``
+
+   * - ``SetMaxAwaitTime()`` 
+     - | The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query.
+       | Default: ``nil``
+
+   * - ``SetComment()`` 
+     - | An arbitrary string to help trace the operation through the database profiler, currentOp and logs.
+       | Default: ``""``
+
+   * - ``SetHint()`` 
+     - | The index to use to scan for documents to retrieve.
+       | Default: ``nil``
+
+   * - ``SetLet()`` 
+     - | Specifies parameters for the aggregate expression, which improves command readability by separating the variables from the query text.
+       | Default: to not specify parameters
 
 Example
 ```````
@@ -211,7 +260,10 @@ For more information on any of the functions or types discussed in this
 guide, see the following API Documentation:
 
 - `Find() <{+api+}/mongo#Collection.Find>`__
+- `FindOptions <{+api+}/mongo/options#FindOptions>`__
+- `FindOneOptions <{+api+}/mongo/options#FindOneOptions>`__
 - `Cursor <{+api+}/mongo#Cursor>`__
 - `FindOne() <{+api+}/mongo#Collection.FindOne>`__
 - `SingleResult <{+api+}/mongo#SingleResult>`__
 - `Aggregate() <{+api+}/mongo#Collection.Aggregate>`__
+- `AggregateOptions <{+api+}/mongo/options#AggregateOptions>`__

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -71,8 +71,8 @@ The ``Find()`` and ``FindOne()`` functions optionally take a
 you can use to modify their behavior. If you don't specify any options,
 the driver uses the default values for each option.
 
-The following table lists the functions to configure the commonly used
-options in both types:
+You can configure the commonly used options in both types with the
+following functions:
 
 .. list-table::
    :widths: 30 70
@@ -160,8 +160,8 @@ type, which represents options you can use to modify its behavior. If
 you don't specify any options, the driver uses the default values for
 each option.
 
-The following table lists the functions to configure the commonly used
-options in both types:
+The ``AggregateOptions`` type allows you to configure options with the
+following functions:
 
 .. list-table::
    :widths: 30 70
@@ -241,7 +241,7 @@ examples:
 - :doc:`Find a Document </usage-examples/findOne>`
 - :doc:`Find Multiple Documents </usage-examples/find>`
 
-For more infomration about the mentioned read operations, see the
+For more infomration about the read operations mentioned, see the
 following guides:
 
 - :doc:`Skip Returned Results </fundamentals/crud/read-operations/skip>`


### PR DESCRIPTION
## Pull Request Info

Added the commonly used FindOptions to the CRUD > Read Operations page. 

Because there are about 20 options for FindOne() and Find(), I documented the commonly used ones (pages we currently/will have) and linked to the API docs for the full list. 

I also: 
- added a FindOne() example
- updated the Find() example to include options

Note: I confirmed with an engineer that I saying "to not specify ..." for default values are more accurate than `nil` for those who don't explicitly say `nil` is the default.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18987

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6165ad088670bd273117baba

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18987-FindOptions/fundamentals/crud/read-operations/retrieve/#modify-behavior

https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18987-FindOptions/fundamentals/crud/read-operations/retrieve/#modify-behavior-1

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
