### PR TITLE
DOCSP-18236 crud count documents

### DIFF
--- a/source/fundamentals/crud/read-operations.txt
+++ b/source/fundamentals/crud/read-operations.txt
@@ -4,6 +4,7 @@ Read Operations
 
 .. default-domain:: mongodb
 
+- :doc:`/fundamentals/crud/read-operations/count`
 - :doc:`/fundamentals/crud/read-operations/retrieve`
 - :doc:`/fundamentals/crud/read-operations/sort`
 - :doc:`/fundamentals/crud/read-operations/skip`

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -1,0 +1,174 @@
+===============
+Count Documents
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to count the number of documents
+in your collection.
+
+Sample Data
+~~~~~~~~~~~
+
+To run the example in this guide, load the sample data into the
+``ratings`` collection of the ``tea`` database with the following
+snippet:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
+   :language: go
+   :dedent:
+   :start-after: begin insert docs
+   :end-before: end insert docs
+
+.. include:: /includes/fundamentals/automatic-db-coll-creation.rst
+
+Each document contains a rating for a type of tea that corresponds to
+the ``type`` and ``rating`` fields.
+
+Accurate Count
+--------------
+
+To count the number of documents that match your query filter, use the
+``CountDocuments()`` function.
+
+.. tip::
+
+   If you pass an empty query filter, the function returns the total
+   number of documents in the collection.
+
+Modify Behavior
+~~~~~~~~~~~~~~~
+
+You can modify the behavior of ``CountDocuments()`` by passing in a
+``CountOptions`` type. If you don't specify any options, the driver uses
+its default values.
+
+The ``CountOptions`` type allows you to configure options with the
+following functions:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetCollation()``
+     - | The type of language collation to use when sorting results.  
+       | Default: ``nil``
+
+   * - ``SetHint()`` 
+     - | The index to use to scan for documents to delete. 
+       | Default: ``nil``
+
+   * - ``SetLimit()`` 
+     - | The maximum number of documents to return. 
+       | Default: ``0`` 
+
+   * - ``SetMaxTime()``
+     - | The maximum amount of time in milliseconds that the query can run on the server.
+       | Default: ``nil``
+
+   * - ``SetSort()`` 
+     - | The number of documents to skip.
+       | Default: ``0``
+
+Example 
+```````
+
+The following example counts the number of documents where the
+``rating`` is less than ``6``:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
+   :language: go
+   :dedent:
+   :start-after: begin count documents
+   :end-before: end count documents
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   Number of ratings less than six: 4
+
+Estimated Count
+---------------
+
+To estimate the number of documents in your collection, use the
+``EstimatedDocumentCount()`` function. 
+
+.. note:: 
+
+    The ``EstimatedDocumentCount()`` function is quicker than the
+    ``CountDocuments()`` function because it uses the collection's
+    metadata rather than scanning the entire collection. 
+
+Modify Behavior
+~~~~~~~~~~~~~~~
+
+You can modify the behavior of ``EstimatedDocumentCount()`` by passing
+in a ``EstimatedDocumentCountOptions`` type. If you don't specify any
+options, the driver uses its default values.
+
+The ``CountOptions`` type allows you to configure options with the
+following functions:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetMaxTime()``
+     - | The maximum amount of time in milliseconds that the query can run on the server.
+       | Default: ``nil``
+
+Example 
+```````
+
+The following example estimtes the number of documents in the
+``ratings`` collection:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
+   :language: go
+   :dedent:
+   :start-after: begin est doc count
+   :end-before: end est doc count
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   Estimated number of documents in the ratings collection: 9
+
+Additional Information
+----------------------
+
+For more information on the read operations mentioned, see the following
+guides:
+
+- :doc:`Sort Results </fundamentals/crud/read-operations/sort>`
+- :doc:`Limit the Number of Returned Results </fundamentals/crud/read-operations/limit>`
+
+.. - :doc:`Collations </fundamentals/collations>`
+.. - :doc:`Specify a Query </fundamentals/crud/query-document>` guide
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+- `CountDocuments() <{+api+}/mongo#Collection.CountDocuments>`__
+- `CountOptions <{+api+}/mongo/options#CountOptions>`__
+- `EstimatedDocumentCount() <{+api+}/mongo#Collection.EstimatedDocumentCount>`__
+- `EstimatedDocumentCountOptions <{+api+}/mongo/options#EstimatedDocumentCountOptions>`__

--- a/source/includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
+		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("tea").Collection("ratings").Drop(context.TODO())
+
+	// begin insert docs
+	coll := client.Database("tea").Collection("ratings")
+	docs := []interface{}{
+		bson.D{{"type", "Masala"}, {"rating", 10}},
+		bson.D{{"type", "Matcha"}, {"rating", 7}},
+		bson.D{{"type", "Assam"}, {"rating", 4}},
+		bson.D{{"type", "Oolong"}, {"rating", 9}},
+		bson.D{{"type", "Chrysanthemum"}, {"rating", 5}},
+		bson.D{{"type", "Earl Grey"}, {"rating", 8}},
+		bson.D{{"type", "Jasmine"}, {"rating", 3}},
+		bson.D{{"type", "English Breakfast"}, {"rating", 6}},
+		bson.D{{"type", "White Peony"}, {"rating", 4}},
+	}
+
+	result, err := coll.InsertMany(context.TODO(), docs)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+	//end insert docs
+
+	{
+		// begin count documents
+		filter := bson.D{{"rating", bson.D{{"$lt", 6}}}}
+
+		count, err := coll.CountDocuments(context.TODO(), filter)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Number of ratings less than six: %d\n", count)
+		// end count documents
+	}
+
+	{
+		// begin est doc count
+		count, err := coll.EstimatedDocumentCount(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Estimated number of documents in the ratings collection: %d\n", count)
+		// end est doc count
+	}
+}

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -44,9 +44,8 @@ After you run the full example, you should see the following:
 Additional Information
 ----------------------
 
-..
-  For more information on counting documents, see our guide on
-  <TODO: Counting Documents>.
+For more information on counting documents, see our guide on
+:doc:`Counting Documents </fundamentals/crud/read-operations/count>`.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Added the Fundamentals > CRUD > Read Operations > Count Documents page.
This page covers `CountDocuments()` and `EstimatedDocumentCount()`.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18236

### Snooty build log:
**Paste your workerpool job link here**

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18236-CRUDCount/fundamentals/crud/read-operations/count/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
