### PR TITLE
DOCSP-19089 connect via atlas links

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -38,8 +38,8 @@ servers in rotation without reconfiguring clients.
 .. note::
 
    If your deployment is on MongoDB Atlas, see the
-   :atlas:`Atlas driver connection guide </driver-connection>`
-   and select Go from the language dropdown to retrieve your connection string.
+   :ref:`Quick Start guide <connect-to-your-cluster>` to learn how to
+   retrieve your connection string.
 
 The next part of the connection string contains your username and, if
 you are using password-based authentication, your password. Replace the value of

--- a/source/includes/quick-start/atlas-setup.rst
+++ b/source/includes/quick-start/atlas-setup.rst
@@ -43,3 +43,7 @@ to your clipboard as shown below.
 
 Save your Atlas connection string in a safe location that you can access
 for the next step.
+
+For more information on conencting to the Go driver through Atlas, see
+the :atlas:`Atlas driver connection guide </driver-connection>`
+and select **Go** from the *Select your language* dropdown.


### PR DESCRIPTION
## Pull Request Info

Updated the link in the connection guide to redirect to the quick start guide to connect to Atlas. Then in the Quick Start guide to redirect to the manual page for more information.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19089

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=616f26a7c13055282db4666a

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-19089-AtlasConnectionLink/fundamentals/connection/

https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-19089-AtlasConnectionLink/quick-start/#set-up-a-free-tier-cluster-in-atlas

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
