### PR TITLE
DOCSP-13840 crud search text

### DIFF
--- a/source/fundamentals/crud/read-operations.txt
+++ b/source/fundamentals/crud/read-operations.txt
@@ -10,11 +10,11 @@ Read Operations
 - :doc:`/fundamentals/crud/read-operations/skip`
 - :doc:`/fundamentals/crud/read-operations/limit`
 - :doc:`/fundamentals/crud/read-operations/project`
+- :doc:`/fundamentals/crud/read-operations/text`
 
 ..
   - :doc:`/fundamentals/crud/read-operations/cursor`
   - :doc:`/fundamentals/crud/read-operations/geo`
-  - :doc:`/fundamentals/crud/read-operations/text`
 
 .. toctree::
    :caption: Read Operations
@@ -25,7 +25,7 @@ Read Operations
    /fundamentals/crud/read-operations/skip
    /fundamentals/crud/read-operations/limit
    /fundamentals/crud/read-operations/project
+   /fundamentals/crud/read-operations/text
 ..
   /fundamentals/crud/read-operations/cursor
   /fundamentals/crud/read-operations/geo
-  /fundamentals/crud/read-operations/text

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -20,7 +20,7 @@ the number of documents in your collection.
 Sample Data
 ~~~~~~~~~~~
 
-To run the example in this guide, load the sample data into the
+To run the examples in this guide, load the sample data into the
 ``ratings`` collection of the ``tea`` database with the following
 snippet:
 

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -167,7 +167,7 @@ guides:
 - :doc:`Retrieve Data </fundamentals/crud/read-operations/retrieve>`
 - :doc:`Compound Operations </fundamentals/crud/compound-operations>`
 
-For information about projecting a text score in your text search, see
+For information about projecting text scores from your text search, see
 our guide on :doc:`Text Search </fundamentals/crud/read-operations/text>`.
 
 .. For more information on aggregation, see the

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -167,6 +167,9 @@ guides:
 - :doc:`Retrieve Data </fundamentals/crud/read-operations/retrieve>`
 - :doc:`Compound Operations </fundamentals/crud/compound-operations>`
 
+For information about projecting a text score in your text search, see
+our guide on :doc:`Text Search </fundamentals/crud/read-operations/text>`.
+
 .. For more information on aggregation, see the
 .. :doc:`Aggregation </fundamentals/aggregation>` guide.
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -203,7 +203,7 @@ guides:
 - :doc:`Retrieve Data </fundamentals/crud/read-operations/retrieve>`
 - :doc:`Compound Operations </fundamentals/crud/compound-operations>`
 
-For information about sorting text scores in your text search, see our
+For information about sorting text scores from your text search, see our
 guide on :doc:`Text Search </fundamentals/crud/read-operations/text>`.
 
 .. For more information on aggregation, see the

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -203,8 +203,8 @@ guides:
 - :doc:`Retrieve Data </fundamentals/crud/read-operations/retrieve>`
 - :doc:`Compound Operations </fundamentals/crud/compound-operations>`
 
-.. For information about sorting text, see our
-.. guide on :doc:`Text Search </fundamentals/crud/write-operations/text>`.
+For information about sorting text scores in your text search, see our
+guide on :doc:`Text Search </fundamentals/crud/read-operations/text>`.
 
 .. For more information on aggregation, see the
 .. :doc:`Aggregation </fundamentals/aggregation>` guide.

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -1,0 +1,278 @@
+===========
+Search Text
+===========
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to run a :ref:`text search <text-search-go>`.
+
+Sample Data
+~~~~~~~~~~~
+
+To run the examples in this guide, load the sample data into the
+``movies`` collection of the ``marvel`` database with the following
+snippet:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin insert docs
+   :end-before: end insert docs
+
+.. include:: /includes/fundamentals/automatic-db-coll-creation.rst
+
+Each document contains the name and release year of the Marvel movie
+that corresponds to the ``title`` and ``year`` fields.
+
+.. include:: /includes/fundamentals/truncated-id.rst
+
+Text Index
+~~~~~~~~~~
+
+You must create a **text index** before running a text search. A text
+index specifies the string or string array field on which to run a text
+search.
+
+The examples in this guide run text searches on the ``title`` field in
+the ``movies`` collection. To enable text searches on the ``title``
+field, create a text index using with the following snippet: 
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin text index
+   :end-before: end text index
+
+.. _text-search-go:
+
+Text Search
+-----------
+
+A text search retrieves documents that contain a **term** or a
+**phrase** in a specified field. A term is a sequence of characters that
+excludes whitespace characters. A phrase is a sequence of terms with any
+number of whitespace characters.
+
+To perform a text search, use the ``$text`` query operator, followed by
+the ``$search`` field in your query filter. The ``$text`` query operator
+performs a text search on the text indexed fields. The ``$search`` field
+specifies the text to search in the text indexed fields.
+
+Query filters for text searches use the following format:
+
+.. code-block:: go
+
+   filter := bson.D{{"$text", bson.D{{"$search", "<text to search>"}}}}
+
+.. _term-search-go:
+
+Search by a Term
+~~~~~~~~~~~~~~~~
+
+To search for a term, pass the term as a string in your query filter.
+To search for multiple terms, separate each term with spaces in the string.
+
+.. note::
+
+   When searching for multiple terms, the driver returns documents with
+   at least one of the terms in text indexed fields.
+   
+
+Example
+```````
+
+The following example runs a text search for titles that contain the term "War":
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin term search
+   :end-before: end term search
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {title Avengers: Infinity War} {year 2018}]
+   [{_id ObjectID("...")} {title Captain America: Civil War} {year 2016}]
+
+Search by a Phrase
+~~~~~~~~~~~~~~~~~~
+
+To search for a phrase, pass the phrase with escaped quotes in your
+query filter. If you don't add escaped quotes around the phrase, the
+``Find()`` function runs a :ref:`term search <term-search-go>`.
+
+.. tip::
+
+   Escaped quotes are double quote characters preceded by a backslash
+   character.
+
+Example
+```````
+
+The following example runs a text search for titles that contain the
+phrase "Infinity War":
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin phrase search
+   :end-before: end phrase search
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {title Avengers: Infinity War} {year 2018}]
+
+Search with Terms Excluded
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For each term you want to exclude from your text search, prefix the term
+with a minus sign in the string in your query filter.
+
+.. important::
+
+   You must have at least one text search term if you want to exclude
+   terms from your search. If there are no text search terms, the driver
+   doesn't return any documents.
+
+Example
+```````
+
+The following example runs a text search for titles that contain the
+terms "Captain" or "America", but does not contain the term "Avenger":
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin exclude term search
+   :end-before: end exclude term search
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {title Captain America: The Winter Soldier} {year 2014}]
+   [{_id ObjectID("...")} {title Captain America: Civil War} {year 2016}]
+
+Sort by Relevance
+~~~~~~~~~~~~~~~~~
+
+The text search assigns a numerical text score to indicate how closely
+each result matches the string in your query filter. To reveal the text
+score in your output, use a projection to retrieve the "textScore"
+metadata.
+
+You can sort the text score in descending order by specifying a sort on
+the "textScore" metadata.
+
+Example
+```````
+
+The following example performs the following actions:
+
+- Runs a text search for titles that contain the term "Avenger"
+- Sorts the results in descending order based on their text score
+- Includes the ``title`` and ``score`` fields from the results
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin phrase search
+   :end-before: end phrase search
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{title The Avengers} {score 1}]
+   [{title Avengers: Infinity War} {score 0.6666666666666666}]
+   [{title Captain America: The First Avenger} {score 0.625}]
+
+Aggregation
+-----------
+
+You can also include the :manual:`$text </reference/operator/query/text/>`
+evaluation operator in the :manual:`$match </reference/operator/aggregation/match/>` stage
+to perform a text search in an aggregation pipeline.
+
+Term Search Example
+~~~~~~~~~~~~~~~~~~~
+
+The following example runs a text search for titles that contain the term "Winter":
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin aggregate text search
+   :end-before: end aggregate text search
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {title Captain America: The Winter Soldier} {year 2014}]
+
+Text Score Example
+~~~~~~~~~~~~~~~~~~
+
+The following example performs the following actions:
+
+- Runs a text search for titles that contain the term "Avenger"
+- Sorts the results in descending order based on their text score
+- Includes the ``title`` and ``score`` fields from the results
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
+   :language: go
+   :dedent:
+   :start-after: begin aggregate text score
+   :end-before: end aggregate text score
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{title The Avengers} {score 1}]
+   [{title Avengers: Infinity War} {score 0.6666666666666666}]
+   [{title Captain America: The First Avenger} {score 0.625}]
+
+Additional Information
+----------------------
+
+For more information on the operations mentioned, see the following
+guides:
+
+- :doc:`</fundamentals/crud/query-document>`
+- :doc:`</fundamentals/crud/read-operations/sort>`
+- :doc:`</fundamentals/crud/read-operations/project>`
+- :manual:`</reference/operator/aggregation/meta/>`
+
+.. - :doc:`</fundamentals/crud/indexes>`
+.. - :doc:`</fundamentals/aggregation>`
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For more information on any of the functions or types discussed in this
+guide, see the following API Documentation:
+
+- `Find() <{+api+}/mongo#Collection.Find>`__
+- `FindOptions.SetSort() <{+api+}/mongo/options#FindOptions.SetSort>`__
+- `FindOptions.SetProjection() <{+api+}/mongo/options#FindOptions.SetProjection>`__

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -83,8 +83,8 @@ To search for multiple terms, separate each term with spaces in the string.
 
 .. note::
 
-   When searching for multiple terms, the function returns documents with
-   at least one of the terms in text indexed fields.
+   When searching for multiple terms, the ``Find()`` function returns
+   documents with at least one of the terms in text indexed fields.
 
 Example
 ```````
@@ -108,9 +108,9 @@ After running this example, the output resembles the following:
 Search by a Phrase
 ~~~~~~~~~~~~~~~~~~
 
-To search for a phrase, specify the phrase with escaped quotes in your
-query filter. If you don't add escaped quotes around the phrase, the
-``Find()`` function runs a :ref:`term search <term-search-go>`.
+To search for a phrase, specify the phrase with escaped quotes as a
+string in your query filter. If you don't add escaped quotes around the
+phrase, the ``Find()`` function runs a :ref:`term search <term-search-go>`.
 
 .. tip::
 
@@ -146,7 +146,7 @@ term prefixed with a minus sign as a string in your query filter.
 
    You must search for at least one term if you want to exclude
    terms from your search. If you don't search for any terms, the
-   function doesn't return any documents.
+   ``Find()`` function doesn't return any documents.
 
 Example
 ```````
@@ -171,12 +171,11 @@ After running this example, the output resembles the following:
 Sort by Relevance
 ~~~~~~~~~~~~~~~~~
 
-The text search assigns a numerical text score to indicate how closely
-each result matches the string in your query filter. 
-
-To reveal the text score in your output, use a projection to retrieve
-the "textScore" metadata. You can sort the text score in descending
-order by specifying a sort on the "textScore" metadata.
+A text search assigns a numerical text score to indicate how closely
+each result matches the string in your query filter. To reveal the text
+score in your output, use a projection to retrieve the "textScore"
+metadata. You can sort the text score in descending order by specifying
+a sort on the "textScore" metadata.
 
 Example
 ```````
@@ -205,9 +204,9 @@ After running this example, the output resembles the following:
 Aggregation
 -----------
 
-You can also include the :manual:`$text </reference/operator/query/text/>`
-evaluation operator in the :manual:`$match </reference/operator/aggregation/match/>` stage
-to perform a text search in an aggregation pipeline.
+You can also include the ``$text`` evaluation query operator in the
+:manual:`$match </reference/operator/aggregation/match/>` stage to
+perform a text search in an aggregation pipeline.
 
 Term Search Example
 ~~~~~~~~~~~~~~~~~~~
@@ -260,6 +259,7 @@ guides:
 - :doc:`Specify a Query </fundamentals/crud/query-document>`
 - :doc:`Sort Results </fundamentals/crud/read-operations/sort>`
 - :doc:`Specify Which Fields to Return </fundamentals/crud/read-operations/project>`
+- :manual:`$text </reference/operator/query/text/>`
 - :manual:`$meta </reference/operator/aggregation/meta/>`
 
 .. - :doc:`Indexes </fundamentals/crud/indexes>`

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -44,7 +44,7 @@ search.
 
 The examples in the following sections run text searches on the
 ``title`` field in the ``movies`` collection. To enable text searches on
-the ``title`` field, create a text index using the following snippet: 
+the ``title`` field, create a text index with the following snippet: 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
    :language: go
@@ -174,9 +174,9 @@ Sort by Relevance
 
 A text search assigns a numerical text score to indicate how closely
 each result matches the string in your query filter. To reveal the text
-score in your output, use a projection to retrieve the "textScore"
+score in your output, use a projection to retrieve the ``textScore``
 metadata. You can sort the text score in descending order by specifying
-a sort on the "textScore" metadata.
+a sort on the ``textScore`` metadata.
 
 Example
 ```````
@@ -201,6 +201,13 @@ After running this example, the output resembles the following:
    [{title The Avengers} {score 1}]
    [{title Avengers: Infinity War} {score 0.6666666666666666}]
    [{title Captain America: The First Avenger} {score 0.625}]
+
+.. tip::
+
+   Although the search term was "Avenger", titles containing "Avengers"
+   were also matched because a MongoDB text index uses suffix stemming to
+   match similar words. For more information about how MongoDB matches
+   terms, see :manual:`Index Entries </core/index-text/#index-entries>`
 
 Aggregation
 -----------

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -39,12 +39,12 @@ Text Index
 ~~~~~~~~~~
 
 You must create a **text index** before running a text search. A text
-index specifies the string or string array field on which to run a text
-search.
+index specifies the string or string array field to run a text
+search on.
 
-The examples in this guide run text searches on the ``title`` field in
-the ``movies`` collection. To enable text searches on the ``title``
-field, create a text index using with the following snippet: 
+The examples in the following sections run text searches on the
+``title`` field in the ``movies`` collection. To enable text searches on
+the ``title`` field, create a text index using with the following snippet: 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
    :language: go
@@ -58,12 +58,12 @@ Text Search
 -----------
 
 A text search retrieves documents that contain a **term** or a
-**phrase** in a specified field. A term is a sequence of characters that
-excludes whitespace characters. A phrase is a sequence of terms with any
-number of whitespace characters.
+**phrase** in the text indexed fields. A term is a sequence of
+characters that excludes whitespace characters. A phrase is a sequence
+of terms with any number of whitespace characters.
 
-To perform a text search, use the ``$text`` query operator, followed by
-the ``$search`` field in your query filter. The ``$text`` query operator
+To perform a text search, use the ``$text`` evaluation query operator,
+followed by the ``$search`` field in your query filter. The ``$text`` operator
 performs a text search on the text indexed fields. The ``$search`` field
 specifies the text to search in the text indexed fields.
 
@@ -78,14 +78,13 @@ Query filters for text searches use the following format:
 Search by a Term
 ~~~~~~~~~~~~~~~~
 
-To search for a term, pass the term as a string in your query filter.
+To search for a term, specify the term as a string in your query filter.
 To search for multiple terms, separate each term with spaces in the string.
 
 .. note::
 
-   When searching for multiple terms, the driver returns documents with
+   When searching for multiple terms, the function returns documents with
    at least one of the terms in text indexed fields.
-   
 
 Example
 ```````
@@ -109,13 +108,13 @@ After running this example, the output resembles the following:
 Search by a Phrase
 ~~~~~~~~~~~~~~~~~~
 
-To search for a phrase, pass the phrase with escaped quotes in your
+To search for a phrase, specify the phrase with escaped quotes in your
 query filter. If you don't add escaped quotes around the phrase, the
 ``Find()`` function runs a :ref:`term search <term-search-go>`.
 
 .. tip::
 
-   Escaped quotes are double quote characters preceded by a backslash
+   Escaped quotes are a backslash character followed by a double quote
    character.
 
 Example
@@ -140,20 +139,20 @@ After running this example, the output resembles the following:
 Search with Terms Excluded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For each term you want to exclude from your text search, prefix the term
-with a minus sign in the string in your query filter.
+For each term you want to exclude from your text search, specify the
+term prefixed with a minus sign as a string in your query filter.
 
 .. important::
 
-   You must have at least one text search term if you want to exclude
-   terms from your search. If there are no text search terms, the driver
-   doesn't return any documents.
+   You must search for at least one term if you want to exclude
+   terms from your search. If you don't search for any terms, the
+   function doesn't return any documents.
 
 Example
 ```````
 
 The following example runs a text search for titles that contain the
-terms "Captain" or "America", but does not contain the term "Avenger":
+phrase "Captain America", but does not contain the term "Avenger":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
    :language: go
@@ -173,12 +172,11 @@ Sort by Relevance
 ~~~~~~~~~~~~~~~~~
 
 The text search assigns a numerical text score to indicate how closely
-each result matches the string in your query filter. To reveal the text
-score in your output, use a projection to retrieve the "textScore"
-metadata.
+each result matches the string in your query filter. 
 
-You can sort the text score in descending order by specifying a sort on
-the "textScore" metadata.
+To reveal the text score in your output, use a projection to retrieve
+the "textScore" metadata. You can sort the text score in descending
+order by specifying a sort on the "textScore" metadata.
 
 Example
 ```````
@@ -192,8 +190,8 @@ The following example performs the following actions:
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
    :language: go
    :dedent:
-   :start-after: begin phrase search
-   :end-before: end phrase search
+   :start-after: begin text score
+   :end-before: end text score
 
 After running this example, the output resembles the following:
 
@@ -259,13 +257,13 @@ Additional Information
 For more information on the operations mentioned, see the following
 guides:
 
-- :doc:`</fundamentals/crud/query-document>`
-- :doc:`</fundamentals/crud/read-operations/sort>`
-- :doc:`</fundamentals/crud/read-operations/project>`
-- :manual:`</reference/operator/aggregation/meta/>`
+- :doc:`Specify a Query </fundamentals/crud/query-document>`
+- :doc:`Sort Results </fundamentals/crud/read-operations/sort>`
+- :doc:`Specify Which Fields to Return </fundamentals/crud/read-operations/project>`
+- :manual:`$meta </reference/operator/aggregation/meta/>`
 
-.. - :doc:`</fundamentals/crud/indexes>`
-.. - :doc:`</fundamentals/aggregation>`
+.. - :doc:`Indexes </fundamentals/crud/indexes>`
+.. - :doc:`Aggregation </fundamentals/aggregation>`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -13,7 +13,13 @@ Search Text
 Overview
 --------
 
-In this guide, you can learn how to run a :ref:`text search <text-search-go>`.
+In this guide, you can learn how to run a :ref:`text search
+<text-search-go>`. 
+
+.. important::
+
+   MongoDB text search is different than :atlas:`Atlas Search
+   </atlas-search/>`.
 
 Sample Data
 ~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -251,6 +251,13 @@ After running this example, the output resembles the following:
    [{title Avengers: Infinity War} {score 0.6666666666666666}]
    [{title Captain America: The First Avenger} {score 0.625}]
 
+.. tip::
+
+   Although the search term was "Avenger", titles containing "Avengers"
+   were also matched because a MongoDB text index uses suffix stemming to
+   match similar words. For more information about how MongoDB matches
+   terms, see :manual:`Index Entries </core/index-text/#index-entries>`
+
 Additional Information
 ----------------------
 
@@ -260,6 +267,7 @@ guides:
 - :doc:`Specify a Query </fundamentals/crud/query-document>`
 - :doc:`Sort Results </fundamentals/crud/read-operations/sort>`
 - :doc:`Specify Which Fields to Return </fundamentals/crud/read-operations/project>`
+- :manual:`Text Indexes </core/index-text/>`
 - :manual:`$text </reference/operator/query/text/>`
 - :manual:`$meta </reference/operator/aggregation/meta/>`
 

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -44,7 +44,7 @@ search.
 
 The examples in the following sections run text searches on the
 ``title`` field in the ``movies`` collection. To enable text searches on
-the ``title`` field, create a text index using with the following snippet: 
+the ``title`` field, create a text index using the following snippet: 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
    :language: go

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -204,10 +204,11 @@ After running this example, the output resembles the following:
 
 .. tip::
 
-   Although the search term was "Avenger", titles containing "Avengers"
-   were also matched because a MongoDB text index uses suffix stemming to
-   match similar words. For more information about how MongoDB matches
-   terms, see :manual:`Index Entries </core/index-text/#index-entries>`
+   Although the search term was "Avenger", the function also matches
+   titles containing "Avengers" because a MongoDB text index uses suffix
+   stemming to match similar words. For more information about how
+   MongoDB matches terms, see :manual:`Index Entries
+   </core/index-text/#index-entries>`.
 
 Aggregation
 -----------
@@ -260,10 +261,11 @@ After running this example, the output resembles the following:
 
 .. tip::
 
-   Although the search term was "Avenger", titles containing "Avengers"
-   were also matched because a MongoDB text index uses suffix stemming to
-   match similar words. For more information about how MongoDB matches
-   terms, see :manual:`Index Entries </core/index-text/#index-entries>`
+   Although the search term was "Avenger", the function also matches
+   titles containing "Avengers" because a MongoDB text index uses suffix
+   stemming to match similar words. For more information about how
+   MongoDB matches terms, see :manual:`Index Entries
+   </core/index-text/#index-entries>`.
 
 Additional Information
 ----------------------

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -39,8 +39,8 @@ Text Index
 ~~~~~~~~~~
 
 You must create a **text index** before running a text search. A text
-index specifies the string or string array field to run a text
-search on.
+index specifies the string or string array field on which to run a text
+search.
 
 The examples in the following sections run text searches on the
 ``title`` field in the ``movies`` collection. To enable text searches on
@@ -139,8 +139,9 @@ After running this example, the output resembles the following:
 Search with Terms Excluded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For each term you want to exclude from your text search, specify the
-term prefixed with a minus sign as a string in your query filter.
+For each term or phrase you want to exclude from your text search,
+specify the term or phrase prefixed with a minus sign as a string in
+your query filter.
 
 .. important::
 
@@ -152,7 +153,7 @@ Example
 ```````
 
 The following example runs a text search for titles that contain the
-phrase "Captain America", but does not contain the term "Avenger":
+term "Avenger", but does not contain the phrase "Captain America":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
    :language: go
@@ -165,8 +166,8 @@ After running this example, the output resembles the following:
 .. code-block:: none
    :copyable: false
 
-   [{_id ObjectID("...")} {title Captain America: The Winter Soldier} {year 2014}]
-   [{_id ObjectID("...")} {title Captain America: Civil War} {year 2016}]
+   [{_id ObjectID("...")} {title The Avengers} {year 2012}]
+   [{_id ObjectID("...")} {title Avengers: Infinity War} {year 2018}]
 
 Sort by Relevance
 ~~~~~~~~~~~~~~~~~

--- a/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
@@ -40,9 +40,9 @@ func main() {
 		bson.D{{"title", "Captain America: The First Avenger"}, {"year", 2011}},
 	}
 
-	result, insertErr := coll.InsertMany(context.TODO(), docs)
-	if insertErr != nil {
-		panic(insertErr)
+	result, err := coll.InsertMany(context.TODO(), docs)
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
 	//end insert docs

--- a/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
@@ -100,7 +100,7 @@ func main() {
 	fmt.Println("Excluded Term Search:")
 	{
 		//begin exclude term search
-		filter := bson.D{{"$text", bson.D{{"$search", "\"Captain America\" -Avenger"}}}}
+		filter := bson.D{{"$text", bson.D{{"$search", "Avenger -\"Captain America\""}}}}
 
 		cursor, err := coll.Find(context.TODO(), filter)
 		if err != nil {

--- a/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
@@ -100,7 +100,7 @@ func main() {
 	fmt.Println("Excluded Term Search:")
 	{
 		//begin exclude term search
-		filter := bson.D{{"$text", bson.D{{"$search", "Captain America -Avenger"}}}}
+		filter := bson.D{{"$text", bson.D{{"$search", "\"Captain America\" -Avenger"}}}}
 
 		cursor, err := coll.Find(context.TODO(), filter)
 		if err != nil {

--- a/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
+		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("marvel").Collection("movies").Drop(context.TODO())
+
+	// begin insert docs
+	coll := client.Database("marvel").Collection("movies")
+	docs := []interface{}{
+		bson.D{{"title", "Captain America: Civil War"}, {"year", 2016}},
+		bson.D{{"title", "The Avengers"}, {"year", 2012}},
+		bson.D{{"title", "Captain America: The Winter Soldier"}, {"year", 2014}},
+		bson.D{{"title", "Avengers: Infinity War"}, {"year", 2018}},
+		bson.D{{"title", "Captain America: The First Avenger"}, {"year", 2011}},
+	}
+
+	result, insertErr := coll.InsertMany(context.TODO(), docs)
+	if insertErr != nil {
+		panic(insertErr)
+	}
+	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+	//end insert docs
+
+	//begin text index
+	model := mongo.IndexModel{Keys: bson.D{{"title", "text"}}}
+	name, err := coll.Indexes().CreateOne(context.TODO(), model)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Name of Index Created: " + name)
+	//end text index
+
+	fmt.Println("Term Search:")
+	{
+		//begin term search
+		filter := bson.D{{"$text", bson.D{{"$search", "War"}}}}
+
+		cursor, err := coll.Find(context.TODO(), filter)
+		if err != nil {
+			panic(err)
+		}
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+		//end term search
+	}
+
+	fmt.Println("Phrase Search:")
+	{
+		//begin phrase search
+		filter := bson.D{{"$text", bson.D{{"$search", "\"Infinity War\""}}}}
+
+		cursor, err := coll.Find(context.TODO(), filter)
+		if err != nil {
+			panic(err)
+		}
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+		//end phrase search
+	}
+
+	fmt.Println("Excluded Term Search:")
+	{
+		//begin exclude term search
+		filter := bson.D{{"$text", bson.D{{"$search", "Captain America -Avenger"}}}}
+
+		cursor, err := coll.Find(context.TODO(), filter)
+		if err != nil {
+			panic(err)
+		}
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+		//end exclude term search
+	}
+
+	fmt.Println("Sort By Relevance:")
+	{
+		//begin text score
+		filter := bson.D{{"$text", bson.D{{"$search", "Avenger"}}}}
+		sort := bson.D{{"score", bson.D{{"$meta", "textScore"}}}}
+		projection := bson.D{{"title", 1}, {"score", bson.D{{"$meta", "textScore"}}}, {"_id", 0}}
+		opts := options.Find().SetSort(sort).SetProjection(projection)
+
+		cursor, err := coll.Find(context.TODO(), filter, opts)
+		if err != nil {
+			panic(err)
+		}
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+		//end text score
+	}
+
+	fmt.Println("Aggregation Text Score:")
+	{
+		// begin aggregate text score
+		matchStage := bson.D{{"$match", bson.D{{"$text", bson.D{{"$search", "Avenger"}}}}}}
+		sortStage := bson.D{{"$sort", bson.D{{"score", bson.D{{ "$meta", "textScore" }}}}}}
+		projectStage := bson.D{{"$project", bson.D{{"title", 1}, {"score", bson.D{{ "$meta", "textScore" }}}, {"_id", 0}}}}
+
+		cursor, err := coll.Aggregate(context.TODO(), mongo.Pipeline{matchStage, sortStage, projectStage})
+		if err != nil {
+			panic(err)
+		}
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+		// end aggregate text score
+	}
+
+	fmt.Println("Aggregation Text Search:")
+	{
+		// begin aggregate text search
+		matchStage := bson.D{{"$match", bson.D{{"$text", bson.D{{"$search", "Winter"}}}}}}
+
+		cursor, err := coll.Aggregate(context.TODO(), mongo.Pipeline{matchStage})
+		if err != nil {
+			panic(err)
+		}
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+		// end aggregate text search
+	}
+}


### PR DESCRIPTION
## Pull Request Info

Added the Fundamentals > CRUD > Read Operations > Search Text page.

The page covers:
- Searching by a term
- Searching by a phrase
- Searching with terms excluded
- Sorting the results by relevance

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13840

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6182c5bdc13055282d559fb4

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13840-CRUDTextSearch/fundamentals/crud/read-operations/text/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
