### PR TITLE
DOCSP-13845 crud update arrays

### DIFF
--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -1,3 +1,5 @@
+.. _compound-operations-golang:
+
 ===================
 Compound Operations
 ===================
@@ -9,8 +11,6 @@ Compound Operations
    :backlinks: none
    :depth: 1
    :class: singlecol
-
-.. _compound-operations-golang:
 
 Overview
 --------

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -10,6 +10,8 @@ Compound Operations
    :depth: 1
    :class: singlecol
 
+.. _compound-operations-golang:
+
 Overview
 --------
 

--- a/source/fundamentals/crud/query-document.txt
+++ b/source/fundamentals/crud/query-document.txt
@@ -1,3 +1,5 @@
+.. _query_document_golang:
+
 ===============
 Specify a Query
 ===============
@@ -9,8 +11,6 @@ Specify a Query
    :backlinks: none
    :depth: 1
    :class: singlecol
-
-.. _query_document_golang:
 
 Overview
 --------

--- a/source/fundamentals/crud/write-operations.txt
+++ b/source/fundamentals/crud/write-operations.txt
@@ -7,10 +7,8 @@ Write Operations
 - :doc:`/fundamentals/crud/write-operations/insert`
 - :doc:`/fundamentals/crud/write-operations/delete`
 - :doc:`/fundamentals/crud/write-operations/change-a-document`
+- :doc:`/fundamentals/crud/write-operations/embedded-arrays`
 - :doc:`/fundamentals/crud/write-operations/upsert`
-
-..
-  - :doc:`/fundamentals/crud/write-operations/embedded-arrays`
 
 .. toctree::
    :caption: Write Operations
@@ -18,7 +16,5 @@ Write Operations
    /fundamentals/crud/write-operations/insert
    /fundamentals/crud/write-operations/delete
    /fundamentals/crud/write-operations/change-a-document
+   /fundamentals/crud/write-operations/embedded-arrays
    /fundamentals/crud/write-operations/upsert
-
-..
-  /fundamentals/crud/write-operations/embedded-arrays

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -1,3 +1,5 @@
+.. _change_document_golang:
+
 =================
 Change a Document
 =================
@@ -9,8 +11,6 @@ Change a Document
    :backlinks: none
    :depth: 2
    :class: singlecol
-
-.. _change_document_golang:
 
 Overview
 --------

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -300,8 +300,8 @@ guides:
 - :doc:`Compound Operations </fundamentals/crud/compound-operations>`
 - :manual:`Update Operators </reference/operator/update/#update-operators>`
 
-For information on updating array elements, see the :doc:`Update Arrays
-in a Document </fundamentals/crud/write-operations/embedded-arrays>` guide.
+For information on updating array elements, see the
+:ref:`<update-arrays-golang>` guide.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -66,6 +66,8 @@ document.
 
 Use the ``UpdateMany()`` function to update multiple documents.
 
+.. _update-document:
+
 Parameters
 ~~~~~~~~~~
 
@@ -297,6 +299,9 @@ guides:
 - :doc:`Insert or Update in a Single Operation </fundamentals/crud/write-operations/upsert>`
 - :doc:`Compound Operations </fundamentals/crud/compound-operations>`
 - :manual:`Update Operators </reference/operator/update/#update-operators>`
+
+For information on updating array elements, see the :doc:`Update Arrays
+in a Document </fundamentals/crud/write-operations/embedded-arrays>` guide.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -1,0 +1,171 @@
+===========================
+Update Arrays in a Document
+===========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to update array elements in a document.
+
+Sample Data
+~~~~~~~~~~~
+
+To run the examples in this guide, load the sample data into the
+``tea`` collection of the ``quantity`` database with the following
+snippet:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
+   :language: go
+   :dedent:
+   :start-after: begin insert docs
+   :end-before: end insert docs
+
+.. include:: /includes/fundamentals/automatic-db-coll-creation.rst
+
+The document contains the number of tea  available
+that corresponds to the ``name`` and ``qty`` fields.
+
+.. include:: /includes/fundamentals/truncated-id.rst
+
+Specify Array Elements
+----------------------
+
+To update elements in an array, perform the following steps:
+
+- Provide an :ref:`update document <update-document>` specifying the update
+- Specify which array elements to update using a **positional operator**
+- Perform the update using an update operation with these specifications
+
+Positional operators can specify the :ref:`first <first-element-go>`,
+:ref:`all <all-elements-go>`, or :ref:`certain <certain-elements-go>`
+array elements to update.
+
+To specify elements in an array with positional operators, use the **dot
+notation**. Dot notation is a property access syntax for navigating
+array elements and fields of an embedded document.
+
+.. _first-element-go:
+
+First Array Element
+~~~~~~~~~~~~~~~~~~~
+
+To update the first array element that matches your query filter, use
+the positional ``$`` operator. The array field must appear as part of
+your query filter to use the positional ``$`` operator. 
+
+Example
+```````
+
+This example performs the following actions:
+
+- Matches the ``qty`` array elements where the value is greater than ``10``
+- Decrements the first array value matched by ``5``
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
+   :language: go
+   :dedent:
+   :start-after: begin positional
+   :end-before: end positional
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID(“…”)} {type Masala} {qty [10 12 18]}]
+
+.. _all-elements-go:
+
+All Array Elements
+~~~~~~~~~~~~~~~~~~
+
+To update all the array elements, use the all positional ``$[]`` operator.
+
+.. tip::
+
+   If you specify a filter for the array field, the positional ``$[]``
+   operator ignores the filter and updates all the array elements.
+
+Example
+```````
+
+This example multiplies all the array elements by ``2``:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
+   :language: go
+   :dedent:
+   :start-after: begin positional all
+   :end-before: end positional all
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {type Masala} {qty [30 24 36]}]
+
+.. _certain-elements-go:
+
+Multiple Array Elements
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To update multiple array elements that match a filter, use the filtered
+positional ``$[<identifier>]`` operator. You must include an array
+filter in your update operation to specify which array elements to
+update.
+
+The ``<identifier>`` is the name you use within your array filter. This
+value must begin with a lowercase letter and only contain alphanumeric
+characters.
+
+Example
+```````
+
+This example performs the following actions:
+
+- Creates an array filter called ``smaller`` to match array elements less than ``18``
+- Increments all matching array elements by ``7``
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
+   :language: go
+   :dedent:
+   :start-after: begin positional
+   :end-before: end positional
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {type Masala} {qty [22 19 18]}]
+
+Additional Information
+----------------------
+
+For more information on the operations mentioned, see the following
+guides:
+
+- :doc:`Specify a Query </fundamentals/crud/query-document>`
+- :doc:`Compound Operations </fundamentals/crud/compound-operations>`
+- :doc:`Change a Document </fundamentals/crud/write-operations/change-a-document>`
+- :manual:`Positional $ Operator </reference/operator/update/positional/>`
+- :manual:`Positional $[] Operator </reference/operator/update/positional-all/>`
+- :manual:`Positional $[<identifier>] Operator </reference/operator/update/positional-filtered/>`
+- :manual:`Dot Notation </core/document/#std-label-document-dot-notation>`
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For more information on any of the functions or types discussed in this
+guide, see the following API Documentation:
+
+- `FindOneAndUpdate() <{+api+}/mongo#Collection.FindOneAndUpdate>`__
+- `FindOneAndUpdateOptions <{+api+}/mongo/options#FindOneAndUpdateOptions>`__

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -10,6 +10,8 @@ Update Arrays in a Document
    :depth: 2
    :class: singlecol
 
+.. _update-arrays-golang:
+
 Overview
 --------
 
@@ -17,9 +19,9 @@ In this guide, you can learn how to update array elements in a document.
 
 To update elements in an array, perform the following actions:
 
-- Provide an :ref:`update document <update-document>` specifying the update *(not discussed in this guide)*
-- Specify which array elements to update
-- Perform the update using an update operation with these specifications
+- Provide an :ref:`update document <update-document>` that specifies the update.
+- Specify which array elements to update.
+- Perform the update using an update operation with these specifications.
 
 Sample Data
 ~~~~~~~~~~~
@@ -37,7 +39,7 @@ snippet:
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
 The following examples use the ``FindOneAndUpdate()`` function to
-retrieve and update a document, and to return the state of the document
+retrieve and update a document and to return the state of the document
 after the update occurs. If you want to update multiple documents with
 an array field, use the ``UpdateMany()`` function.
 
@@ -48,10 +50,10 @@ Specify Array Elements
 
 To specify which array elements to update, use a **positional
 operator**. Positional operators can specify the :ref:`first <first-element-go>`,
-:ref:`all <all-elements-go>`, or :ref:`multiple <multiple-elements-go>`
+:ref:`multiple <multiple-elements-go>`, or :ref:`all <all-elements-go>`
 array elements to update.
 
-To specify array elements with a positional operator, use the **dot
+To specify array elements with a positional operator, use **dot
 notation**. Dot notation is a property access syntax for navigating
 array elements and fields of an embedded document.
 
@@ -69,8 +71,8 @@ Example
 
 This example performs the following actions:
 
-- Matches array elements in ``qty`` where the value is greater than ``10``
-- Decrements the first array value matched by ``5``
+- Matches array elements in ``qty`` where the value is greater than ``10``.
+- Decrements the first array value matched by ``5``.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
    :language: go
@@ -87,10 +89,46 @@ After running this example, the output resembles the following:
 
 .. note::
 
-   The query filter matched the values ``15`` and ``12``. Since ``15``
-   was the first element matched, it got updated. If you want to update
+   The query filter matches the values ``15`` and ``12``. Since ``15``
+   is the first element matched, it is updated. If you want to update
    both matched values, see the :ref:`Multiple Array Elements section
    <multiple-elements-go>`.
+
+.. _multiple-elements-go:
+
+Multiple Array Elements
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To update multiple array elements that match your query filter, use the
+filtered positional ``$[<identifier>]`` operator. You must include an
+array filter in your update operation to specify which array elements to
+update.
+
+The ``<identifier>`` is the name you use within your array filter. This
+value must begin with a lowercase letter and only contain alphanumeric
+characters.
+
+Example
+```````
+
+This example performs the following actions:
+
+- Creates an array filter with an identifier called ``smaller`` to match elements less than ``18``.
+- Applies the array filter using the ``SetArrayFilters()`` function.
+- Increments every matched element by ``7``.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
+   :language: go
+   :dedent:
+   :start-after: begin filtered positional
+   :end-before: end filtered positional
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {type Masala} {qty [22 19 18]}]
 
 .. _all-elements-go:
 
@@ -123,51 +161,15 @@ After running this example, the output resembles the following:
 
    [{_id ObjectID("...")} {type Masala} {qty [30 24 36]}]
 
-.. _multiple-elements-go:
-
-Multiple Array Elements
-~~~~~~~~~~~~~~~~~~~~~~~
-
-To update multiple array elements that match your query filter, use the
-filtered positional ``$[<identifier>]`` operator. You must include an
-array filter in your update operation to specify which array elements to
-update.
-
-The ``<identifier>`` is the name you use within your array filter. This
-value must begin with a lowercase letter and only contain alphanumeric
-characters.
-
-Example
-```````
-
-This example performs the following actions:
-
-- Creates an array filter with an identifier called ``smaller`` to match elements less than ``18``
-- Applies the array filter using the ``SetArrayFilters()`` function
-- Increments every matched element by ``7``
-
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
-   :language: go
-   :dedent:
-   :start-after: begin filtered positional
-   :end-before: end filtered positional
-
-After running this example, the output resembles the following:
-
-.. code-block:: none
-   :copyable: false
-
-   [{_id ObjectID("...")} {type Masala} {qty [22 19 18]}]
-
 Additional Information
 ----------------------
 
-For more information on the operations mentioned, see the following
-guides:
+For more information on the operations discussed in this guide, see the
+following guides:
 
-- :doc:`Specify a Query </fundamentals/crud/query-document>`
-- :doc:`Compound Operations </fundamentals/crud/compound-operations>`
-- :doc:`Change a Document </fundamentals/crud/write-operations/change-a-document>`
+- :ref:`<query_document_golang>`
+- :ref:`<compound-operations-golang>`
+- :ref:`<change_document_golang>`
 - :manual:`Positional $ Operator </reference/operator/update/positional/>`
 - :manual:`Positional $[] Operator </reference/operator/update/positional-all/>`
 - :manual:`Positional $[\<identifier\>] Operator </reference/operator/update/positional-filtered/>`

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -1,3 +1,5 @@
+.. _update-arrays-golang:
+
 ===========================
 Update Arrays in a Document
 ===========================
@@ -9,8 +11,6 @@ Update Arrays in a Document
    :backlinks: none
    :depth: 2
    :class: singlecol
-
-.. _update-arrays-golang:
 
 Overview
 --------

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -15,6 +15,12 @@ Overview
 
 In this guide, you can learn how to update array elements in a document.
 
+To update elements in an array, perform the following steps:
+
+- Provide an :ref:`update document <update-document>` specifying the update
+- Specify which array elements to update
+- Perform the update using an update operation with these specifications
+
 Sample Data
 ~~~~~~~~~~~
 
@@ -30,22 +36,19 @@ snippet:
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
-The document contains the number of tea  available
-that corresponds to the ``name`` and ``qty`` fields.
+The following examples use the ``FindOneAndUpdate()`` function to
+retrieve and update a document, and to return the state of the document
+after the update occurs. If you want to update multiple documents with
+an array field, use the ``UpdateMany()`` function.
 
 .. include:: /includes/fundamentals/truncated-id.rst
 
 Specify Array Elements
 ----------------------
 
-To update elements in an array, perform the following steps:
-
-- Provide an :ref:`update document <update-document>` specifying the update
-- Specify which array elements to update using a **positional operator**
-- Perform the update using an update operation with these specifications
-
-Positional operators can specify the :ref:`first <first-element-go>`,
-:ref:`all <all-elements-go>`, or :ref:`certain <certain-elements-go>`
+To specify which array elements to update, use a **positional
+operator**. Positional operators can specify the :ref:`first <first-element-go>`,
+:ref:`all <all-elements-go>`, or :ref:`multiple <multiple-elements-go>`
 array elements to update.
 
 To specify elements in an array with positional operators, use the **dot
@@ -58,15 +61,15 @@ First Array Element
 ~~~~~~~~~~~~~~~~~~~
 
 To update the first array element that matches your query filter, use
-the positional ``$`` operator. The array field must appear as part of
-your query filter to use the positional ``$`` operator. 
+the positional ``$`` operator. The query filter must be for the array
+field.
 
 Example
 ```````
 
 This example performs the following actions:
 
-- Matches the ``qty`` array elements where the value is greater than ``10``
+- Matches array elements in ``qty`` where the value is greater than ``10``
 - Decrements the first array value matched by ``5``
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
@@ -82,6 +85,13 @@ After running this example, the output resembles the following:
 
    [{_id ObjectID(“…”)} {type Masala} {qty [10 12 18]}]
 
+.. note::
+
+   The query filter matched the values ``15`` and ``12``. Since ``15``
+   was the first element matched, it got updated. If you want to update
+   both matched values, see the ::ref:`Multiple Array Elements section
+   <multiple-elements-go>`.
+
 .. _all-elements-go:
 
 All Array Elements
@@ -91,13 +101,14 @@ To update all the array elements, use the all positional ``$[]`` operator.
 
 .. tip::
 
-   If you specify a filter for the array field, the positional ``$[]``
-   operator ignores the filter and updates all the array elements.
+   If you specify a query filter for the array field, the positional
+   ``$[]`` operator ignores the query filter and updates all the array
+   elements.
 
 Example
 ```````
 
-This example multiplies all the array elements by ``2``:
+This example multiplies every array element in ``qty`` by ``2``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
    :language: go
@@ -112,7 +123,7 @@ After running this example, the output resembles the following:
 
    [{_id ObjectID("...")} {type Masala} {qty [30 24 36]}]
 
-.. _certain-elements-go:
+.. _multiple-elements-go:
 
 Multiple Array Elements
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -131,14 +142,15 @@ Example
 
 This example performs the following actions:
 
-- Creates an array filter called ``smaller`` to match array elements less than ``18``
-- Increments all matching array elements by ``7``
+- Creates an array filter called ``smaller`` to match elements less than ``18``
+- Applies the array filter using the ``SetArrayFilter()`` function
+- Increments every matched element by ``7``
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
    :language: go
    :dedent:
-   :start-after: begin positional
-   :end-before: end positional
+   :start-after: begin filtered positional
+   :end-before: end filtered positional
 
 After running this example, the output resembles the following:
 
@@ -169,3 +181,4 @@ guide, see the following API Documentation:
 
 - `FindOneAndUpdate() <{+api+}/mongo#Collection.FindOneAndUpdate>`__
 - `FindOneAndUpdateOptions <{+api+}/mongo/options#FindOneAndUpdateOptions>`__
+- `UpdateMany() <{+api+}/mongo#Collection.UpdateMany>`__

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -15,9 +15,9 @@ Overview
 
 In this guide, you can learn how to update array elements in a document.
 
-To update elements in an array, perform the following steps:
+To update elements in an array, perform the following actions:
 
-- Provide an :ref:`update document <update-document>` specifying the update
+- Provide an :ref:`update document <update-document>` specifying the update *(not discussed in this guide)*
 - Specify which array elements to update
 - Perform the update using an update operation with these specifications
 
@@ -51,7 +51,7 @@ operator**. Positional operators can specify the :ref:`first <first-element-go>`
 :ref:`all <all-elements-go>`, or :ref:`multiple <multiple-elements-go>`
 array elements to update.
 
-To specify elements in an array with positional operators, use the **dot
+To specify array elements with a positional operator, use the **dot
 notation**. Dot notation is a property access syntax for navigating
 array elements and fields of an embedded document.
 
@@ -89,7 +89,7 @@ After running this example, the output resembles the following:
 
    The query filter matched the values ``15`` and ``12``. Since ``15``
    was the first element matched, it got updated. If you want to update
-   both matched values, see the ::ref:`Multiple Array Elements section
+   both matched values, see the :ref:`Multiple Array Elements section
    <multiple-elements-go>`.
 
 .. _all-elements-go:
@@ -99,7 +99,7 @@ All Array Elements
 
 To update all the array elements, use the all positional ``$[]`` operator.
 
-.. tip::
+.. note::
 
    If you specify a query filter for the array field, the positional
    ``$[]`` operator ignores the query filter and updates all the array
@@ -128,9 +128,9 @@ After running this example, the output resembles the following:
 Multiple Array Elements
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-To update multiple array elements that match a filter, use the filtered
-positional ``$[<identifier>]`` operator. You must include an array
-filter in your update operation to specify which array elements to
+To update multiple array elements that match your query filter, use the
+filtered positional ``$[<identifier>]`` operator. You must include an
+array filter in your update operation to specify which array elements to
 update.
 
 The ``<identifier>`` is the name you use within your array filter. This
@@ -142,8 +142,8 @@ Example
 
 This example performs the following actions:
 
-- Creates an array filter called ``smaller`` to match elements less than ``18``
-- Applies the array filter using the ``SetArrayFilter()`` function
+- Creates an array filter with an identifier called ``smaller`` to match elements less than ``18``
+- Applies the array filter using the ``SetArrayFilters()`` function
 - Increments every matched element by ``7``
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
@@ -170,7 +170,7 @@ guides:
 - :doc:`Change a Document </fundamentals/crud/write-operations/change-a-document>`
 - :manual:`Positional $ Operator </reference/operator/update/positional/>`
 - :manual:`Positional $[] Operator </reference/operator/update/positional-all/>`
-- :manual:`Positional $[<identifier>] Operator </reference/operator/update/positional-filtered/>`
+- :manual:`Positional $[\<identifier\>] Operator </reference/operator/update/positional-filtered/>`
 - :manual:`Dot Notation </core/document/#std-label-document-dot-notation>`
 
 API Documentation
@@ -180,5 +180,6 @@ For more information on any of the functions or types discussed in this
 guide, see the following API Documentation:
 
 - `FindOneAndUpdate() <{+api+}/mongo#Collection.FindOneAndUpdate>`__
-- `FindOneAndUpdateOptions <{+api+}/mongo/options#FindOneAndUpdateOptions>`__
+- `FindOneAndUpdateOptions.SetReturnDocument() <{+api+}/mongo/options#FindOneAndUpdateOptions.SetReturnDocument>`__
+- `FindOneAndUpdateOptions.SetArrayFilters() <{+api+}/mongo/options#FindOneAndUpdateOptions.SetArrayFilters>`__
 - `UpdateMany() <{+api+}/mongo#Collection.UpdateMany>`__

--- a/source/includes/fundamentals/code-snippets/CRUD/updateArray.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/updateArray.go
@@ -64,15 +64,24 @@ func main() {
 		// end positional
 	}
 
+	{
+		update := bson.D{{"$set", bson.D{{"qty", bson.A{15, 12, 18} }}}}
+
+		result, err := coll.UpdateOne(context.TODO(), bson.D{}, update)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%v document was updated.\n", result.ModifiedCount)
+	}
+
 	fmt.Println("Positional $[] Operator:")
 	{
 		// begin positional all
-		filter := bson.D{}
 		update := bson.D{{"$mul", bson.D{{"qty.$[]", 2}}}}
 		opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
 
 		var updatedDoc bson.D
-		err := coll.FindOneAndUpdate(context.TODO(), filter, update, opts).Decode(&updatedDoc)
+		err := coll.FindOneAndUpdate(context.TODO(), bson.D{}, update, opts).Decode(&updatedDoc)
 		if err != nil {
 			panic(err)
 		}
@@ -81,16 +90,26 @@ func main() {
 		// end positional all
 	}
 
+
+	{
+		update := bson.D{{"$set", bson.D{{"qty", bson.A{15, 12, 18} }}}}
+
+		result, err := coll.UpdateOne(context.TODO(), bson.D{}, update)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%v document was updated.\n", result.ModifiedCount)
+	}
+
 	fmt.Println("Positional $[<identifier>] Operator:")
 	{
 		// begin filtered positional
-		filter := bson.D{}
 		identifier := []interface{}{bson.D{{"smaller", bson.D{{"$lt", 18}}}}}
 		update := bson.D{{"$inc", bson.D{{"qty.$[smaller]", 7}}}}
 		opts := options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{Filters: identifier}).SetReturnDocument(options.After)
 
 		var updatedDoc bson.D
-		err := coll.FindOneAndUpdate(context.TODO(), filter, update, opts).Decode(&updatedDoc)
+		err := coll.FindOneAndUpdate(context.TODO(), bson.D{}, update, opts).Decode(&updatedDoc)
 		if err != nil {
 			panic(err)
 		}

--- a/source/includes/fundamentals/code-snippets/CRUD/updateArray.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/updateArray.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
+		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("tea").Collection("quantity").Drop(context.TODO())
+
+	// begin insert docs
+	coll := client.Database("tea").Collection("quantity")
+	docs := []interface{}{
+		bson.D{{"type", "Masala"}, {"qty", bson.A{15, 12, 18}}},
+	}
+
+	result, err := coll.InsertMany(context.TODO(), docs)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%d documents inserted with IDs:\n", len(result.InsertedIDs))
+	// end insert docs
+
+	for _, id := range result.InsertedIDs {
+		fmt.Printf("\t%s\n", id)
+	}
+
+	fmt.Println("Positional $ Operator:")
+	{
+		// begin positional
+		filter := bson.D{{"qty", bson.D{{"$gt", 10}}}}
+		update := bson.D{{"$inc", bson.D{{"qty.$", -5}}}}
+		opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+
+		var updatedDoc bson.D
+		err := coll.FindOneAndUpdate(context.TODO(), filter, update, opts).Decode(&updatedDoc)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(updatedDoc)
+		// end positional
+	}
+
+	fmt.Println("Positional $[] Operator:")
+	{
+		// begin positional all
+		filter := bson.D{}
+		update := bson.D{{"$mul", bson.D{{"qty.$[]", 2}}}}
+		opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+
+		var updatedDoc bson.D
+		err := coll.FindOneAndUpdate(context.TODO(), filter, update, opts).Decode(&updatedDoc)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(updatedDoc)
+		// end positional all
+	}
+
+	fmt.Println("Positional $[<identifier>] Operator:")
+	{
+		// begin filtered positional
+		filter := bson.D{}
+		identifier := []interface{}{bson.D{{"smaller", bson.D{{"$lt", 18}}}}}
+		update := bson.D{{"$inc", bson.D{{"qty.$[smaller]", 7}}}}
+		opts := options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{Filters: identifier}).SetReturnDocument(options.After)
+
+		var updatedDoc bson.D
+		err := coll.FindOneAndUpdate(context.TODO(), filter, update, opts).Decode(&updatedDoc)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(updatedDoc)
+		// end filtered positional
+	}
+}


### PR DESCRIPTION
## Pull Request Info

Added the Fundamentals > CRUD > Write Operations > Update Arrays in a Document page.

This page covers the different positional operators.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13845

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6171e59fc13055282db5dcaa

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13845-CRUDUpdateArrays/fundamentals/crud/write-operations/embedded-arrays/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
