### PR TITLE
DOCSP-18350 crud bulk operations

### DIFF
--- a/source/fundamentals/crud/query-document.txt
+++ b/source/fundamentals/crud/query-document.txt
@@ -18,6 +18,8 @@ Overview
 In this guide, you can learn how to specify a query to match a subset
 of documents.
 
+.. _query-filter-definition-go:
+
 To match a subset of documents, specify a **query filter** containing
 your **match criteria**. Match criteria consist of the fields and
 values you want present in a document. A query filter contains at least

--- a/source/fundamentals/crud/write-operations.txt
+++ b/source/fundamentals/crud/write-operations.txt
@@ -9,6 +9,7 @@ Write Operations
 - :doc:`/fundamentals/crud/write-operations/change-a-document`
 - :doc:`/fundamentals/crud/write-operations/embedded-arrays`
 - :doc:`/fundamentals/crud/write-operations/upsert`
+- :doc:`/fundamentals/crud/write-operations/bulk`
 
 .. toctree::
    :caption: Write Operations
@@ -18,3 +19,4 @@ Write Operations
    /fundamentals/crud/write-operations/change-a-document
    /fundamentals/crud/write-operations/embedded-arrays
    /fundamentals/crud/write-operations/upsert
+   /fundamentals/crud/write-operations/bulk

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -1,0 +1,320 @@
+===============
+Bulk Operations
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _bulk_golang:
+
+Overview
+--------
+
+In this guide, you can learn how to use :ref:`bulk operations <bulk-write-go>`.
+
+Sample Data
+~~~~~~~~~~~
+
+To run the example in this guide, load the sample data into the
+``ratings`` collection of the ``tea`` database with the following
+snippet:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
+   :language: go
+   :dedent:
+   :start-after: begin insert docs
+   :end-before: end insert docs
+
+.. include:: /includes/fundamentals/tea-sample-data-ending.rst
+
+.. _bulk-write-go:
+
+Write Models
+------------
+
+Bulk operations perform a large number of write operations. Instead of
+making a call for each operation to the database, bulk operations
+perform multiple operations with one call to the database.
+
+To perform a bulk operation, pass a slice of ``WriteModel`` documents to
+the ``BulkWrite()`` function. A ``WriteModel`` represents an insert,
+replace, update or delete operation.
+
+The ``BulkWrite()`` function optionally take a ``BulkWriteOptions`` type
+as a third parameter, which represents options you can use to configure
+the bulk operation. If you don't specify a ``BulkWriteOptions``, the
+driver uses the default values for each option.
+
+The ``BulkWriteOptions`` type allows you to configure options with the
+following functions:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetBypassDocumentValidation()`` 
+     - | Whether to allow the write to opt-out of document level validation.
+       | Default: ``false``
+
+   * - ``SetOrdered()``
+     - | Whether to stop performing write operations after an error occurs. 
+       | Default: ``true``
+
+Insert Operation
+~~~~~~~~~~~~~~~~
+
+To perform an insert operation, create an ``InsertOneModel`` specifying
+the document you want to insert. To insert multiple documents, you must
+create an ``InsertOneModel`` for each document you want to insert.
+
+The ``InsertOneModel`` allows you to specify its behavior with the
+following function:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetDocument()`` 
+     - | The document to insert.
+
+Example
+```````
+
+This following example creates two ``InsertOneModel`` instances to
+insert two documents:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
+   :language: go
+   :dedent:
+   :start-after: begin bulk insert model
+   :end-before: end bulk insert model
+
+Replace Operation
+~~~~~~~~~~~~~~~~~
+
+To perform a replace operation, create a ``ReplaceOneModel`` specifying
+the document you want to replace and a replacement document. To replace
+multiple documents, you must create an ``ReplaceOneModel`` for each
+document you want to replace.
+
+The ``ReplaceOneModel`` allows you to specify its behavior with the
+following functions:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetCollation()`` 
+     - | The type of language collation to use when sorting results.
+
+   * - ``SetFilter()`` 
+     - | The document to replace.
+
+   * - ``SetHint()`` 
+     - | The index to use to scan for documents.
+
+   * - ``SetReplacement()`` 
+     - | The document to replace the matched document with.
+
+   * - ``SetUpsert()`` 
+     - | Whether to insert a new document if the query filter doesn't match any documents.
+
+Example
+```````
+
+The following example creates a ``ReplaceOneModel`` to replace a
+document where the ``type`` is "Earl Grey" with a document where the
+``type`` is "Matcha" and the ``rating`` is ``8``:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
+   :language: go
+   :dedent:
+   :start-after: begin bulk replace model
+   :end-before: end bulk replace model
+
+Update Operation
+~~~~~~~~~~~~~~~~
+
+To perform an update operation, create an ``UpdateOneModel`` specifying
+the document you want to update and an :ref:`update document
+<update-document>`. To update multiple documents, use the
+``UpdateManyModel``.
+
+The ``UpdateOneModel`` and ``UpdateManyModel`` allow you to specify
+their behavior with the following functions:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetArrayFilters()`` 
+     - | The array elements the update applies to.
+
+   * - ``SetCollation()`` 
+     - | The type of language collation to use when sorting results.
+
+   * - ``SetFilter()`` 
+     - | The document to update.
+
+   * - ``SetHint()`` 
+     - | The index to use to scan for documents.
+
+   * - ``SetUpdate()`` 
+     - | The modifications to apply on the matched documents.
+
+   * - ``SetUpsert()`` 
+     - | Whether to insert a new document if the query filter doesn't match any documents.
+
+Example
+```````
+
+The following example creates a ``UpdateOneModel`` to decrement a
+document whose ``type`` is "Masala", ``rating`` by ``2``:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
+   :language: go
+   :dedent:
+   :start-after: begin bulk update model
+   :end-before: end bulk update model
+
+Delete
+~~~~~~
+
+To perform a delete operation, create a ``DeleteOneModel`` specifying
+the document you want to delete. To delete multiple documents, use the
+``DeleteManyModel``. 
+
+The ``DeleteOneModel`` and ``DeleteManyModel`` allow you to specify
+their behavior with the following functions:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``SetCollation()`` 
+     - | The type of language collation to use when sorting results.
+
+   * - ``SetFilter()`` 
+     - | The document to delete.
+
+   * - ``SetHint()`` 
+     - | The index to use to scan for documents.
+
+Example
+```````
+
+The following example creates a ``DeleteManyModel`` to delete
+documents where the ``rating`` is greater than ``7``:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
+   :language: go
+   :dedent:
+   :start-after: begin bulk delete model
+   :end-before: end bulk delete model
+
+Execution Order
+---------------
+
+The ``BulkWrite()`` function accepts an optional ``BulkWriteOptions`` as
+a third parameter to specify if you want to execute the bulk operations
+as ordered or unordered.
+
+Ordered
+~~~~~~~
+
+By default, the ``BulkWrite()`` function executes bulk operations in
+order. This means that the write operations execute in the order you
+added them until an error occurs, if any.
+
+Unordered
+~~~~~~~~~
+
+To execute bulk operations in any order, specify "false" to the
+``SetOrdered()`` function. This means that all the write operations
+execute regardless of errors and reports errors at the end.
+
+Example
+```````
+
+The following example performs the following actions in any order: 
+
+- Inserts two documents
+- Replaces a document where the type if "Earl Grey" with a new document
+- Increments all documents ``rating`` by ``3`` if their current rating is less than ``7``
+- Deletes all documents where the rating is ``9``
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
+   :language: go
+   :dedent:
+   :start-after: begin bulk delete model
+   :end-before: end bulk delete model
+
+After running this example, the output resembles the following:
+
+.. code-block:: none
+   :copyable: false
+
+   Number of documents inserted: 2
+   Number of documents replaced or updated: 3
+   Number of documents deleted: 2
+
+The following documents are in the ``ratings`` collection after the bulk
+operation:
+
+.. code-block:: none
+   :copyable: false
+
+   [{_id ObjectID("...")} {type Masala} {rating 10}]
+   [{_id ObjectID("...")} {type Matcha} {rating 7}]
+
+
+Additional Information
+----------------------
+
+For a runnable example on perfomring a bulk operation, see the
+:ref:`<bulk-ops-usage-example-go>` usage example.
+
+For more information on performing the operations mentioned, see the
+following guides:
+
+- :ref:`<query_document_golang>`
+- :ref:`<insert_guide_golang>`
+- :ref:`<change_document_golang>`
+- :ref:`<delete_guide_golang>`
+- :manual:`Bulk Write Operations </core/bulk-write-operations/>`
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For more information on any of the functions or types discussed in this
+guide, see the following API Documentation:
+
+- `BulkWrite() <{+api+}/mongo#Collection.BulkWrite>`__
+- `NewInsertOneModel() <{+api+}/mongo#NewUpdateOneModel>`__
+- `NewReplaceOneModel() <{+api+}/mongo#NewReplaceOneModel>`__
+- `NewReplaceOneModel() <{+api+}/mongo#NewReplaceOneModel>`__
+- `NewUpdateOneModel() <{+api+}/mongo#NewUpdateOneModel>`__
+- `NewUpdateManyModel() <{+api+}/mongo#NewReplaceOneModel>`__
+- `NewDeleteOneModel() <{+api+}/mongo#NewReplaceOneModel>`__
+- `NewDeleteManyModel() <{+api+}/mongo#NewReplaceOneModel>`__
+- `BulkWriteResult <{+api+}/mongo#BulkWriteResult>`__

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -1,3 +1,5 @@
+.. _bulk_golang:
+
 ===============
 Bulk Operations
 ===============
@@ -10,12 +12,14 @@ Bulk Operations
    :depth: 2
    :class: singlecol
 
-.. _bulk_golang:
-
 Overview
 --------
 
-In this guide, you can learn how to use :ref:`bulk operations <bulk-write-go>`.
+In this guide, you can learn how to use **bulk operations**.
+
+Bulk operations perform a large number of write operations. Instead of
+making a call for each operation to the database, bulk operations
+perform multiple operations with one call to the database.
 
 Sample Data
 ~~~~~~~~~~~
@@ -32,20 +36,14 @@ snippet:
 
 .. include:: /includes/fundamentals/tea-sample-data-ending.rst
 
-.. _bulk-write-go:
-
-Write Models
-------------
-
-Bulk operations perform a large number of write operations. Instead of
-making a call for each operation to the database, bulk operations
-perform multiple operations with one call to the database.
+Operations
+----------
 
 To perform a bulk operation, pass a slice of ``WriteModel`` documents to
 the ``BulkWrite()`` function. A ``WriteModel`` represents an insert,
 replace, update or delete operation.
 
-The ``BulkWrite()`` function optionally take a ``BulkWriteOptions`` type
+The ``BulkWrite()`` function optionally takes a ``BulkWriteOptions`` type
 as a third parameter, which represents options you can use to configure
 the bulk operation. If you don't specify a ``BulkWriteOptions``, the
 driver uses the default values for each option.
@@ -104,9 +102,9 @@ Replace Operation
 ~~~~~~~~~~~~~~~~~
 
 To perform a replace operation, create a ``ReplaceOneModel`` specifying
-the document you want to replace and a replacement document. To replace
-multiple documents, you must create an ``ReplaceOneModel`` for each
-document you want to replace.
+the document you want to replace and a :ref:`replacement document
+<replacement-document>`. To replace multiple documents, you must create
+an ``ReplaceOneModel`` for each document you want to replace.
 
 The ``ReplaceOneModel`` allows you to specify its behavior with the
 following functions:
@@ -122,7 +120,7 @@ following functions:
      - | The type of language collation to use when sorting results.
 
    * - ``SetFilter()`` 
-     - | The document to replace.
+     - | The query filter specifying which document to replace.
 
    * - ``SetHint()`` 
      - | The index to use to scan for documents.
@@ -171,7 +169,7 @@ their behavior with the following functions:
      - | The type of language collation to use when sorting results.
 
    * - ``SetFilter()`` 
-     - | The document to update.
+     - | The query filter specifying which document to update.
 
    * - ``SetHint()`` 
      - | The index to use to scan for documents.
@@ -185,8 +183,8 @@ their behavior with the following functions:
 Example
 ```````
 
-The following example creates a ``UpdateOneModel`` to decrement a
-document whose ``type`` is "Masala", ``rating`` by ``2``:
+The following example creates an ``UpdateOneModel`` to decrement a
+documents ``rating`` by ``2`` if their ``type`` is "Masala":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
@@ -194,8 +192,8 @@ document whose ``type`` is "Masala", ``rating`` by ``2``:
    :start-after: begin bulk update model
    :end-before: end bulk update model
 
-Delete
-~~~~~~
+Delete Operation
+~~~~~~~~~~~~~~~~
 
 To perform a delete operation, create a ``DeleteOneModel`` specifying
 the document you want to delete. To delete multiple documents, use the
@@ -215,7 +213,7 @@ their behavior with the following functions:
      - | The type of language collation to use when sorting results.
 
    * - ``SetFilter()`` 
-     - | The document to delete.
+     - | The query filter specifying which document to delete.
 
    * - ``SetHint()`` 
      - | The index to use to scan for documents.
@@ -235,23 +233,33 @@ documents where the ``rating`` is greater than ``7``:
 Execution Order
 ---------------
 
-The ``BulkWrite()`` function accepts an optional ``BulkWriteOptions`` as
-a third parameter to specify if you want to execute the bulk operations
-as ordered or unordered.
+The ``BulkWrite()`` function allows you to specify if you want to
+execute the bulk operations as ordered or unordered in its
+``BulkWriteOptions``. 
 
-Ordered
-~~~~~~~
+Ordered Execution
+~~~~~~~~~~~~~~~~~
 
 By default, the ``BulkWrite()`` function executes bulk operations in
 order. This means that the write operations execute in the order you
-added them until an error occurs, if any.
+added them and stops if an error occurs.
 
-Unordered
-~~~~~~~~~
+.. tip::
+
+   This is equivalent to specifying ``true`` in the ``SetOrdered()``
+   function: 
+
+   .. code-block:: go
+
+      opts := options.BulkWrite().SetOrdered(true)
+
+Unordered Execution
+~~~~~~~~~~~~~~~~~~~
 
 To execute bulk operations in any order, specify "false" to the
 ``SetOrdered()`` function. This means that all the write operations
-execute regardless of errors and reports errors at the end.
+execute and continues if an error occurs. The function reports the
+errors afterwards.
 
 Example
 ```````
@@ -266,8 +274,8 @@ The following example performs the following actions in any order:
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
    :dedent:
-   :start-after: begin bulk delete model
-   :end-before: end bulk delete model
+   :start-after: begin bulk unordered
+   :end-before: end bulk unordered
 
 After running this example, the output resembles the following:
 
@@ -310,6 +318,8 @@ For more information on any of the functions or types discussed in this
 guide, see the following API Documentation:
 
 - `BulkWrite() <{+api+}/mongo#Collection.BulkWrite>`__
+- `BulkWriteOptions <{+api+}/mongo/options#BulkWriteOptions>`__
+- `BulkWriteResult <{+api+}/mongo#BulkWriteResult>`__
 - `NewInsertOneModel() <{+api+}/mongo#NewUpdateOneModel>`__
 - `NewReplaceOneModel() <{+api+}/mongo#NewReplaceOneModel>`__
 - `NewReplaceOneModel() <{+api+}/mongo#NewReplaceOneModel>`__
@@ -317,4 +327,3 @@ guide, see the following API Documentation:
 - `NewUpdateManyModel() <{+api+}/mongo#NewReplaceOneModel>`__
 - `NewDeleteOneModel() <{+api+}/mongo#NewReplaceOneModel>`__
 - `NewDeleteManyModel() <{+api+}/mongo#NewReplaceOneModel>`__
-- `BulkWriteResult <{+api+}/mongo#BulkWriteResult>`__

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -86,7 +86,7 @@ contains information about the bulk operation if it's successful. The
      - The number of documents inserted.
 
    * - ``MatchedCount``
-     - The number of documents matched by the filter in update and replace operations.
+     - The number of documents matched by the :ref:`query filter <query-filter-definition-go>` in update and replace operations.
 
    * - ``ModifiedCount``
      - The number of documents modified by update and replace operations.
@@ -95,20 +95,20 @@ contains information about the bulk operation if it's successful. The
      - The number of documents deleted.
    
    * - ``UpsertedCount`` 
-     - The number of documents upserted by update and replace operations.
+     - The number of documents :ref:`upserted <upsert-definition-go>` by update and replace operations.
 
    * - ``UpsertedID`` 
-     - The ``_id`` of the upserted documents.
+     - The ``_id`` of the :ref:`upserted <upsert-definition-go>` documents.
 
 .. _write-model-go:
 
 Operations
 ----------
 
-A ``WriteModel`` represents an insert, replace, update or delete operation.
+A ``WriteModel`` represents an insert, replace, update, or delete operation.
 
-Insert Operation
-~~~~~~~~~~~~~~~~
+Insert
+~~~~~~
 
 To perform an insert operation, create an ``InsertOneModel`` specifying
 the document you want to insert. To insert multiple documents, create an
@@ -139,8 +139,8 @@ insert two documents:
    :start-after: begin bulk insert model
    :end-before: end bulk insert model
 
-Replace Operation
-~~~~~~~~~~~~~~~~~
+Replace
+~~~~~~~
 
 To perform a replace operation, create a ``ReplaceOneModel`` specifying
 the document you want to replace and a :ref:`replacement document
@@ -161,7 +161,7 @@ following functions:
      - | The type of language collation to use when sorting results.
 
    * - ``SetFilter()`` 
-     - | The query filter specifying which document to replace.
+     - | The :ref:`query filter <query-filter-definition-go>` specifying which document to replace.
 
    * - ``SetHint()`` 
      - | The index to use to scan for documents.
@@ -170,7 +170,7 @@ following functions:
      - | The document to replace the matched document with.
 
    * - ``SetUpsert()`` 
-     - | Whether to insert a new document if the query filter doesn't match any documents.
+     - | Whether to insert a new document if the :ref:`query filter <query-filter-definition-go>` doesn't match any documents.
 
 Example
 ```````
@@ -185,8 +185,8 @@ document where the ``type`` is "Earl Grey" with a document where the
    :start-after: begin bulk replace model
    :end-before: end bulk replace model
 
-Update Operation
-~~~~~~~~~~~~~~~~
+Update
+~~~~~~
 
 To perform an update operation, create an ``UpdateOneModel`` specifying
 the document you want to update and an :ref:`update document
@@ -210,7 +210,7 @@ their behavior with the following functions:
      - | The type of language collation to use when sorting results.
 
    * - ``SetFilter()`` 
-     - | The query filter specifying which document to update.
+     - | The :ref:`query filter <query-filter-definition-go>` specifying which document to update.
 
    * - ``SetHint()`` 
      - | The index to use to scan for documents.
@@ -219,7 +219,7 @@ their behavior with the following functions:
      - | The modifications to apply on the matched documents.
 
    * - ``SetUpsert()`` 
-     - | Whether to insert a new document if the query filter doesn't match any documents.
+     - | Whether to insert a new document if the :ref:`query filter <query-filter-definition-go>` doesn't match any documents.
 
 Example
 ```````
@@ -233,8 +233,8 @@ documents ``rating`` by ``2`` if their ``type`` is "Masala":
    :start-after: begin bulk update model
    :end-before: end bulk update model
 
-Delete Operation
-~~~~~~~~~~~~~~~~
+Delete
+~~~~~~
 
 To perform a delete operation, create a ``DeleteOneModel`` specifying
 the document you want to delete. To delete multiple documents, use the
@@ -254,7 +254,7 @@ their behavior with the following functions:
      - | The type of language collation to use when sorting results.
 
    * - ``SetFilter()`` 
-     - | The query filter specifying which document to delete.
+     - | The :ref:`query filter <query-filter-definition-go>` specifying which document to delete.
 
    * - ``SetHint()`` 
      - | The index to use to scan for documents.
@@ -278,8 +278,8 @@ The ``BulkWrite()`` function allows you to specify if you want to
 execute the bulk operations as ordered or unordered in its
 ``BulkWriteOptions``. 
 
-Ordered Execution
-~~~~~~~~~~~~~~~~~
+Ordered
+~~~~~~~
 
 By default, the ``BulkWrite()`` function executes bulk operations in
 order. This means that the write operations execute in the order you
@@ -294,10 +294,10 @@ added them and stops if an error occurs.
 
       opts := options.BulkWrite().SetOrdered(true)
 
-Unordered Execution
-~~~~~~~~~~~~~~~~~~~
+Unordered
+~~~~~~~~~
 
-To execute bulk operations in any order, specify "false" to the
+To execute bulk write operations in any order, specify ``false`` to the
 ``SetOrdered()`` function. This means that all the write operations
 execute and continues if an error occurs. The function reports the
 errors afterwards.
@@ -308,7 +308,7 @@ Example
 The following example performs the following actions in any order: 
 
 - Inserts two documents
-- Replaces a document where the type if "Earl Grey" with a new document
+- Replaces a document where the type is "Earl Grey" with a new document
 - Increments all documents ``rating`` by ``3`` if their current rating is less than ``7``
 - Deletes all documents where the rating is ``9``
 
@@ -342,6 +342,9 @@ Additional Information
 
 For a runnable example on perfomring a bulk operation, see the
 :ref:`<bulk-ops-usage-example-go>` usage example.
+
+Related Operations
+~~~~~~~~~~~~~~~~~~
 
 For more information on performing the operations mentioned, see the
 following guides:

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -36,17 +36,19 @@ snippet:
 
 .. include:: /includes/fundamentals/tea-sample-data-ending.rst
 
-Operations
+Bulk Write
 ----------
 
-To perform a bulk operation, pass a slice of ``WriteModel`` documents to
-the ``BulkWrite()`` function. A ``WriteModel`` represents an insert,
-replace, update or delete operation.
+To perform a bulk operation, pass a slice of :ref:`WriteModel
+<write-model-go>` documents to the ``BulkWrite()`` function. 
 
-The ``BulkWrite()`` function optionally takes a ``BulkWriteOptions`` type
-as a third parameter, which represents options you can use to configure
-the bulk operation. If you don't specify a ``BulkWriteOptions``, the
-driver uses the default values for each option.
+Modify Behavior
+~~~~~~~~~~~~~~~
+
+The ``BulkWrite()`` function optionally takes a ``BulkWriteOptions``
+type, which represents options you can use to modify its behavior. If
+you don't specify a ``BulkWriteOptions``, the driver uses the default
+values for each option.
 
 The ``BulkWriteOptions`` type allows you to configure options with the
 following functions:
@@ -66,12 +68,51 @@ following functions:
      - | Whether to stop performing write operations after an error occurs. 
        | Default: ``true``
 
+Return Values
+~~~~~~~~~~~~~
+
+The ``BulkWrite()`` function returns a ``BulkWriteResult`` type, which
+contains information about the bulk operation if it's successful. The
+``BulkWriteResult`` type contains the following properties:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Property
+     - Description
+
+   * - ``InsertedCount``
+     - The number of documents inserted.
+
+   * - ``MatchedCount``
+     - The number of documents matched by the filter in update and replace operations.
+
+   * - ``ModifiedCount``
+     - The number of documents modified by update and replace operations.
+
+   * - ``DeletedCount``
+     - The number of documents deleted.
+   
+   * - ``UpsertedCount`` 
+     - The number of documents upserted by update and replace operations.
+
+   * - ``UpsertedID`` 
+     - The ``_id`` of the upserted documents.
+
+.. _write-model-go:
+
+Operations
+----------
+
+A ``WriteModel`` represents an insert, replace, update or delete operation.
+
 Insert Operation
 ~~~~~~~~~~~~~~~~
 
 To perform an insert operation, create an ``InsertOneModel`` specifying
-the document you want to insert. To insert multiple documents, you must
-create an ``InsertOneModel`` for each document you want to insert.
+the document you want to insert. To insert multiple documents, create an
+``InsertOneModel`` for each document you want to insert.
 
 The ``InsertOneModel`` allows you to specify its behavior with the
 following function:
@@ -103,8 +144,8 @@ Replace Operation
 
 To perform a replace operation, create a ``ReplaceOneModel`` specifying
 the document you want to replace and a :ref:`replacement document
-<replacement-document>`. To replace multiple documents, you must create
-an ``ReplaceOneModel`` for each document you want to replace.
+<replacement-document>`. To replace multiple documents, create a
+``ReplaceOneModel`` for each document you want to replace.
 
 The ``ReplaceOneModel`` allows you to specify its behavior with the
 following functions:
@@ -274,8 +315,8 @@ The following example performs the following actions in any order:
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
    :dedent:
-   :start-after: begin bulk unordered
-   :end-before: end bulk unordered
+   :start-after: begin unordered
+   :end-before: end unordered
 
 After running this example, the output resembles the following:
 

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -97,8 +97,8 @@ contains information about the bulk operation if it's successful. The
    * - ``UpsertedCount`` 
      - The number of documents :ref:`upserted <upsert-definition-go>` by update and replace operations.
 
-   * - ``UpsertedID`` 
-     - The ``_id`` of the :ref:`upserted <upsert-definition-go>` documents.
+   * - ``UpsertedIDs`` 
+     - A map of an operation index to the ``_id`` of each :ref:`upserted <upsert-definition-go>` document.
 
 .. _write-model-go:
 
@@ -333,7 +333,6 @@ the bulk operation:
 
    [{_id ObjectID("...")} {type Masala} {rating 10}]
    [{_id ObjectID("...")} {type Matcha} {rating 7}]
-
 
 Additional Information
 ----------------------

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -282,8 +282,7 @@ Ordered
 ~~~~~~~
 
 By default, the ``BulkWrite()`` function executes bulk operations in
-order. This means that the write operations execute in the order you
-added them and stops if an error occurs.
+order you added them and stops if an error occurs.
 
 .. tip::
 
@@ -297,20 +296,19 @@ added them and stops if an error occurs.
 Unordered
 ~~~~~~~~~
 
-To execute bulk write operations in any order, specify ``false`` to the
-``SetOrdered()`` function. This means that all the write operations
-execute and continues if an error occurs. The function reports the
-errors afterwards.
+To execute bulk write operations in any order and continue if an error
+occurs, specify ``false`` to the ``SetOrdered()`` function. The function
+reports the errors afterwards.
 
 Example
 ```````
 
 The following example performs the following actions in any order: 
 
-- Inserts two documents
-- Replaces a document where the type is "Earl Grey" with a new document
-- Increments all documents ``rating`` by ``3`` if their current rating is less than ``7``
-- Deletes all documents where the rating is ``9``
+- Inserts two documents.
+- Replaces a document where the type is "Earl Grey" with a new document.
+- Increments all documents ``rating`` by ``3`` if their current rating is less than ``7``.
+- Deletes all documents where the rating is ``9``.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
@@ -327,8 +325,8 @@ After running this example, the output resembles the following:
    Number of documents replaced or updated: 3
    Number of documents deleted: 2
 
-The following documents are in the ``ratings`` collection after the bulk
-operation:
+The following documents are present in the ``ratings`` collection after
+the bulk operation:
 
 .. code-block:: none
    :copyable: false
@@ -340,7 +338,7 @@ operation:
 Additional Information
 ----------------------
 
-For a runnable example on perfomring a bulk operation, see the
+For a runnable example on performing a bulk operation, see the
 :ref:`<bulk-ops-usage-example-go>` usage example.
 
 Related Operations

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -185,7 +185,7 @@ The following shows the updated document resulting from the preceding update ope
       ...
    }
 
-.. _replacementDocument:
+.. _replacement-document:
 
 Replace
 -------

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -1,3 +1,5 @@
+.. _delete_guide_golang:
+
 =================
 Delete a Document
 =================
@@ -9,8 +11,6 @@ Delete a Document
    :backlinks: none
    :depth: 2
    :class: singlecol
-
-.. _delete_guide_golang:
 
 Overview
 --------

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -1,3 +1,5 @@
+.. _insert_guide_golang:
+
 =================
 Insert a Document
 =================
@@ -10,7 +12,6 @@ Insert a Document
    :depth: 2
    :class: singlecol
 
-.. _insert_guide_golang:
 
 Overview
 --------

--- a/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	var uri string
-	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
 		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
 	}
 

--- a/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
+		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("tea").Collection("ratings").Drop(context.TODO())
+
+	// begin insert docs
+	coll := client.Database("tea").Collection("ratings")
+	docs := []interface{}{
+		bson.D{{"type", "Masala"}, {"rating", 10}},
+		bson.D{{"type", "Earl Grey"}, {"rating", 5}},
+	}
+
+	result, err := coll.InsertMany(context.TODO(), docs)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+	// end insert docs
+
+	fmt.Println("InsertOneModel:")
+	{
+		// begin bulk insert model
+		models := []mongo.WriteModel{
+			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Oolong"}, {"rating", 9}}),
+			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Assam"}, {"rating", 6}}),
+		}
+		// end bulk insert model
+
+		results, err := coll.BulkWrite(context.TODO(), models)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Number of documents inserted: %d\n", results.InsertedCount)
+	}
+
+	fmt.Println("Documents After Insert:")
+	{
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+		defer cursor.Close(context.TODO())
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+	}
+
+	fmt.Println("ReplaceOneModel:")
+	{
+		// begin bulk replace model
+		models := []mongo.WriteModel{
+			mongo.NewReplaceOneModel().SetFilter(bson.D{{"type", "Earl Grey"}}).
+				SetReplacement(bson.D{{"type", "Matcha"}, {"rating", 8}}),
+		}
+		// end bulk replace model
+		
+		results, err := coll.BulkWrite(context.TODO(), models)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Number of documents replaced: %d\n", results.ModifiedCount)
+	}
+
+	fmt.Println("Documents After Replace:")
+	{
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+		defer cursor.Close(context.TODO())
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+	}
+	
+	fmt.Println("UpdateOneModel:")
+	{
+		// begin bulk update model
+		models := []mongo.WriteModel{
+			mongo.NewUpdateOneModel().SetFilter(bson.D{{"type", "Masala"}}).
+				SetUpdate(bson.D{{"$inc", bson.D{{"rating", -2}}}}),
+		}
+		// end bulk update model
+		
+		results, err := coll.BulkWrite(context.TODO(), models)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Number of documents updated: %d\n", results.ModifiedCount)
+	}
+
+	fmt.Println("Documents After Update:")
+	{
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+		defer cursor.Close(context.TODO())
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+	}
+
+	fmt.Println("DeleteManyModel:")
+	{
+		// begin bulk delete model
+		models := []mongo.WriteModel{
+			mongo.NewDeleteManyModel().SetFilter(bson.D{{"rating", bson.D{{"$gt", 7}}}}),
+		}
+		// end bulk delete model
+		
+		results, err := coll.BulkWrite(context.TODO(), models)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Number of documents deleted: %d\n", results.DeletedCount)
+	}
+
+	fmt.Println("Documents After Delete:")
+	{
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+		defer cursor.Close(context.TODO())
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+	}
+
+	{
+		client.Database("tea").Collection("ratings").Drop(context.TODO())
+
+		// begin insert docs
+		coll := client.Database("tea").Collection("ratings")
+		docs := []interface{}{
+			bson.D{{"type", "Masala"}, {"rating", 10}},
+			bson.D{{"type", "Earl Grey"}, {"rating", 5}},
+		}
+
+		result, err := coll.InsertMany(context.TODO(), docs)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+		// end insert docs
+	}
+
+	fmt.Println("BulkOperation Example:")
+	{
+		// begin unordered
+		models := []mongo.WriteModel{
+			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Oolong"}, {"rating", 9}}),
+			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Assam"}, {"rating", 6}}),
+			mongo.NewReplaceOneModel().SetFilter(bson.D{{"type", "Earl Grey"}}).
+				SetReplacement(bson.D{{"type", "Matcha"}, {"rating", 4}}),
+			mongo.NewUpdateManyModel().SetFilter(bson.D{{"rating", bson.D{{"$lt", 7}}}}).
+				SetUpdate(bson.D{{"$inc", bson.D{{"rating", 3}}}}),
+			mongo.NewDeleteManyModel().SetFilter(bson.D{{"rating", 9}}),
+		}
+		opts := options.BulkWrite().SetOrdered(false)
+
+		results, err := coll.BulkWrite(context.TODO(), models, opts)
+		if err != nil {
+			panic(err)
+		}
+		
+		fmt.Printf("Number of documents inserted: %d\n", results.InsertedCount)
+		fmt.Printf("Number of documents replaced or updated: %d\n", results.ModifiedCount)
+		fmt.Printf("Number of documents deleted: %d\n", results.DeletedCount)
+		// end unordered
+	}
+
+	fmt.Println("Documents After Bulk Operation:")
+	{
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+		defer cursor.Close(context.TODO())
+
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+	}
+}

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -51,10 +51,7 @@ Additional Information
 ----------------------
 
 For more information on performing bulk write operations on a collection
-and handling potential errors, see the following guides:
-
--  :ref:`<bulk_golang>`
-- :manual:`Bulk Write Operations </core/bulk-write-operations/>`
+and handling potential errors, see the :ref:`<bulk_golang>` guide.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -1,3 +1,5 @@
+.. _bulk-ops-usage-example-go:
+
 =======================
 Perform Bulk Operations
 =======================
@@ -48,13 +50,11 @@ a Document Usage Example </usage-examples/findOne>`.
 Additional Information
 ----------------------
 
-..
-  For more information on performing bulk write operations on a collection
-  and handling potential errors, see our guide on <TODO: Bulk Write
-  Fundamentals>.
+For more information on performing bulk write operations on a collection
+and handling potential errors, see the following guides:
 
-For more information, see our :manual:`Bulk Write Operations
-</core/bulk-write-operations/>` page.
+-  :ref:`<bulk_golang>`
+- :manual:`Bulk Write Operations </core/bulk-write-operations/>`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Added the Fundamentals > CRUD > Write Operations > Bulk Operations page.

This page discusses:
- The write models you can use
- The difference between ordered and unordered operations

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18350

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=617ffe5bc13055282dabb2c5

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-18350-CRUDBulkOperations/fundamentals/crud/write-operations/bulk/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
