### PR TITLE
DOCSP-13833 crud cursor

### DIFF
--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -1,3 +1,5 @@
+.. _bson-golang:
+
 ==============
 Work with BSON
 ==============
@@ -20,6 +22,8 @@ BSON is called **marshalling**, while the reverse process is called **unmarshall
 You should read this guide if you want to learn more about how the Go Driver
 represents BSON data or need to adjust default marshalling
 and unmarshalling behaviors.
+
+.. _bson-types:
 
 Data Types
 ----------

--- a/source/fundamentals/crud/read-operations.txt
+++ b/source/fundamentals/crud/read-operations.txt
@@ -6,6 +6,7 @@ Read Operations
 
 - :doc:`/fundamentals/crud/read-operations/count`
 - :doc:`/fundamentals/crud/read-operations/retrieve`
+- :doc:`/fundamentals/crud/read-operations/cursor`
 - :doc:`/fundamentals/crud/read-operations/distinct`
 - :doc:`/fundamentals/crud/read-operations/sort`
 - :doc:`/fundamentals/crud/read-operations/skip`
@@ -13,7 +14,6 @@ Read Operations
 - :doc:`/fundamentals/crud/read-operations/project`
 
 ..
-  - :doc:`/fundamentals/crud/read-operations/cursor`
   - :doc:`/fundamentals/crud/read-operations/geo`
   - :doc:`/fundamentals/crud/read-operations/text`
 
@@ -22,12 +22,12 @@ Read Operations
    
    /fundamentals/crud/read-operations/count
    /fundamentals/crud/read-operations/retrieve
+   /fundamentals/crud/read-operations/cursor
    /fundamentals/crud/read-operations/distinct
    /fundamentals/crud/read-operations/sort
    /fundamentals/crud/read-operations/skip
    /fundamentals/crud/read-operations/limit
    /fundamentals/crud/read-operations/project
 ..
-  /fundamentals/crud/read-operations/cursor
   /fundamentals/crud/read-operations/geo
   /fundamentals/crud/read-operations/text

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -59,15 +59,15 @@ The method returns a document if each of the following is true:
    :start-after: begin cursor next
    :end-before: end cursor next
 
-Non-blocking Alternative
-~~~~~~~~~~~~~~~~~~~~~~~~
+Tailable Cursor
+~~~~~~~~~~~~~~~
 
-To attempt retrieving a document from your cursor without blocking the
-current goroutine, use the ``TryNext()`` method.
+To attempt retrieving a document from a :manual:`tailable cursor
+</core/tailable-cursors/>`, use the ``TryNext()`` method.
 
 The method returns a document if each of the following is true:
 
-- A document is currently  or will later be available
+- A document is currently or will later be available
 - No errors occurred
 - The context didn't expire
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -1,8 +1,239 @@
+.. _cursor-golang:
+
 =========================
 Access Data From a Cursor
 =========================
 
 .. default-domain:: mongodb
 
-Read operations that return multiple documents do not immediately return
-all values matching the query.
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to access data with a **cursor**.
+
+A cursor is a mechanism that allows an application to iterate over
+database results while holding a subset of them in memory at a given
+time. The Go driver uses a cursor in read operations to return matched
+documents in batches as opposed to all at once.
+
+Retrieve Sample Data
+~~~~~~~~~~~~~~~~~~~~
+
+Each section assumes you retrieve all the documents in your collection
+with the following snippet:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin find
+   :end-before: end find
+
+Access Cursor Elements
+----------------------
+
+You can access a cursors elements before it's exhausted. You exhaust a
+cursor when you iterate through its results and reach its last element.
+Afterwards, the cursor won't respond to functions to access its elements.
+
+.. important::
+
+   A cursor is not goroutine safe. You should not use the same cursor in
+   multiple goroutines at the same time. 
+
+Current Document
+~~~~~~~~~~~~~~~~
+
+When :ref:`iterating through your cursors results
+<cursor-iteration-golang>`, you can view each document as a BSON or Go
+type.
+
+BSON
+````
+
+To access the current document as raw ``BSON``, use the ``Current``
+property.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin current
+   :end-before: end current
+
+Go type
+```````
+
+To access the current document as a Go type, use the ``Decode()``
+function. 
+
+This function unmarshals the current document into the BSON interface
+you specify. It returns any errors from the unmarshalling process
+without any modification.
+
+.. code-block:: go
+
+   var result bson.D
+   if err := cursor.Decode(&result); err != nil {
+      log.Fatal(err)
+   }
+   fmt.Println(result)
+
+Remaining Batch Length
+~~~~~~~~~~~~~~~~~~~~~~
+
+To retrieve the amount of doucments remaining in the current batch, use
+the ``RemainingBatchLength()`` function.
+
+.. note::
+
+   If the amount is ``0``, making a call to ``Next()`` or ``TryNext()``
+   does a network request to fetch the next batch. 
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin remaining batch length
+   :end-before: end remaining batch length
+
+Cursor ID
+~~~~~~~~~
+
+To retrive the ID of the cursor, use the ``ID()`` function. 
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin id
+   :end-before: end id
+
+.. important::
+
+   Include a ``FindOptions.SetBatchSize()`` with a batch size less than or
+   equal to the number of documents you expect to retrieve for a valid
+   cursor ID. If you omit this option, set the batch size to greater than
+   the elements retrieved, or exhaust the cursor, the cursor ID is
+   ``0``.
+   
+   .. code-block:: go
+      
+      opts := options.Find().SetBatchSize(3)
+      cursor, err := coll.Find(context.TODO(), bson.D{}, opts)
+      if err != nil {
+         panic(err)
+      }
+
+Errors
+~~~~~~
+
+To retrieve the last error the cursor encountered, use the ``Err()``
+function. The error is ``nil`` if no errors occured.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin err
+   :end-before: end err
+
+.. _cursor-iteration-golang:
+
+Iteration
+---------
+
+A cursor allows you to access query results one document at a time,
+abstracting away network and caching logic.
+
+.. note::
+   
+   If you previously used the cursor to iterate some documents, the
+   driver excluses those documents in its results when you iterate
+   again. 
+
+All
+~~~
+
+To unmarshal all documents stored in the cursor into an array at the
+same time, use the ``All()`` function.
+
+This function automatically closes the cursor after retrieving all
+documents.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin cursor all
+   :end-before: end cursor all
+
+Next
+~~~~
+
+To block until a document is available, an error occurs, or the context
+expires, use the ``Next()`` function.
+
+The function returns ``true`` if no errors occur and you didn't exhaust
+the cursor. Otherwise, the function returns ``false``.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin cursor next
+   :end-before: end cursor next
+
+Attempt Next
+~~~~~~~~~~~~~
+
+To attempt retriving the next document in a cursor, use the
+``TryNext()`` function. 
+
+The function returns ``false`` if the driver exhausts the cursor, an
+error occurs, the next document isn't available or the context expires.
+Otherwise, the function returns ``true``.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin cursor try next
+   :end-before: end cursor try next
+
+Cursor Cleanup
+--------------
+
+To free up a cursor's consumption of resources in both the client
+application and the MongoDB server, use the ``Close()`` function. 
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin close
+   :end-before: end close
+
+Additional Information
+----------------------
+
+For more information on the operations discussed in this guide, see the
+following guides:
+
+- :ref:`<retrieve-golang>`
+- :ref:`<bson-unmarshalling>`
+
+.. - Fundamentals > BSON page
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For more information on any of the functions or types discussed in this
+guide, see the following API Documentation:
+
+- `Cursor <{+api+}/mongo#Cursor>`__
+- `Cursor.Decode() <{+api+}/mongo#Cursor.Decode>`__
+- `Cursor.RemainingBatchLength() <{+api+}/mongo#Cursor.RemainingBatchLength>`__
+- `Cursor.ID() <{+api+}/mongo#Cursor.ID>`__
+- `Cursor.Err() <{+api+}/mongo#Cursor.Err>`__
+- `Cursor.All() <{+api+}/mongo#Cursor.All`__
+- `Cursor.Next() <{+api+}/mongo#Cursor.Next>`__
+- `Cursor.TryNext() <{+api+}/mongo#Cursor.TryNext>`__
+- `Cursor.Close() <{+api+}/mongo#Cursor.Close>`__

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -38,9 +38,9 @@ Access Cursor Elements
 ----------------------
 
 You can access a cursors elements before it's **exhausted**. A cursor is
-exhausted when you iterate through its results and reach its last
-element. Afterwards, the cursor won't respond to functions to access its
-elements.
+exhausted when the ``MongoClient`` iterates through its results and
+reaches its last element. Afterwards, the cursor won't respond to
+functions to access its elements.
 
 .. important::
 
@@ -51,8 +51,8 @@ Current Document
 ~~~~~~~~~~~~~~~~
 
 When :ref:`iterating through your cursors results
-<cursor-iteration-golang>`, you can view each document as a BSON or Go
-type.
+<cursor-iteration-golang>`, you can view each document as a ``BSON`` or
+Go value.
 
 BSON
 ````
@@ -66,15 +66,15 @@ property.
    :start-after: begin current
    :end-before: end current
 
-Go type
-```````
+Go Value
+````````
 
-To access the current document as a Go type, use the ``Decode()``
+To access the current document as a Go value, use the ``Decode()``
 function. 
 
-This function unmarshals the current document into the BSON interface
-you specify. It returns any errors from the unmarshalling process
-without any modification.
+This function unmarshals the current document into the :ref:`BSON
+interface <bson-types>` you specify. It returns any errors from the
+unmarshalling process without any modification.
 
 .. code-block:: go
 
@@ -87,7 +87,7 @@ without any modification.
 Remaining Batch Length
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To retrieve the amount of doucments remaining in the current batch, use
+To retrieve the amount of documents remaining in the current batch, use
 the ``RemainingBatchLength()`` function.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
@@ -104,7 +104,7 @@ the ``RemainingBatchLength()`` function.
 Cursor ID
 ~~~~~~~~~
 
-To retrive the ID of the cursor, use the ``ID()`` function. 
+To retrieve the ID of the cursor, use the ``ID()`` function. 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -117,8 +117,8 @@ To retrive the ID of the cursor, use the ``ID()`` function.
    Include the option to set your batch size. The batch size needs to be
    a number less than or equal to the number of documents you expect to
    retrieve for a valid cursor ID. If you omit this option, set the
-   batch size to greater than the elements retrieved, or the cursor is
-   exhausted, the cursor ID is ``0``.
+   batch size to greater than the elements retrieved, or the
+   ``MongoClient`` exhausts the cursor, the cursor ID is ``0``.
    
    .. code-block:: go
       
@@ -132,7 +132,7 @@ Errors
 ~~~~~~
 
 To retrieve the last error the cursor encountered, use the ``Err()``
-function. The error is ``nil`` if no errors occured.
+function. The error is ``nil`` if no errors occurred.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -142,25 +142,26 @@ function. The error is ``nil`` if no errors occured.
 
 .. _cursor-iteration-golang:
 
-Iteration
----------
+Usage Patterns
+--------------
 
 A cursor allows you to access query results one document at a time,
-abstracting away network and caching logic.
+abstracting away network and caching logic. 
 
 .. note::
    
    If you previously used the cursor to iterate some documents, the
-   driver excluses those documents when you iterate again. 
+   driver excludes those documents when you iterate again. 
 
-All
-~~~
+Functional Iteration
+~~~~~~~~~~~~~~~~~~~~
 
-To unmarshal all documents stored in the cursor into an array at the
-same time, use the ``All()`` function.
+To iterate through all results, use the ``All()`` function. 
 
-This function automatically closes the cursor after retrieving all
-documents.
+This function unmarshals all the documents stored in a cursor into an
+array at the same time. ``All()`` makes your cursor non-tailable. This
+means that the cursor automatically closes after the ``MongoClient``
+exhausts it.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -168,14 +169,25 @@ documents.
    :start-after: begin cursor all
    :end-before: end cursor all
 
-Next
-~~~~
+Manual Iteration
+~~~~~~~~~~~~~~~~
 
-To block until a document is available, an error occurs, or the context
-expires, use the ``Next()`` function.
+To iterate through each result or to purposely wait for the next
+available document, use the ``Next()`` function. 
 
-The function returns ``true`` if no errors occur and the cursor isn't
-exhausted. Otherwise, the function returns ``false``.
+.. tip::
+
+   While going through each result, you can further specify how you want
+   the documents printed though the find operations options. 
+
+This function blocks the current goroutine until a document is
+available, an error occurs, or the context expires. It returns ``true``
+if no errors occur and the ``MongoClient`` didn't exhaust the cursor.
+Otherwise, the function returns ``false``.
+
+``Next()`` makes your cursor tailable. This means that the cursor
+remains open after the ``MongoClient`` exhausts it.
+   
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -184,14 +196,17 @@ exhausted. Otherwise, the function returns ``false``.
    :end-before: end cursor next
 
 Attempt Next
-~~~~~~~~~~~~~
+````````````
 
-To attempt retriving the next document in a cursor, use the
-``TryNext()`` function. 
+Alternatively, you can use the ``TryNext()`` function.
 
-The function returns ``false`` if the cursor is exhausted, an error
-occurs, the next document isn't available or the context expires.
-Otherwise, the function returns ``true``.
+This function attempts to retrieve the next document in a cursor. It's
+non-blocking, which means it returns ``false`` if the ``MongoClient``
+exhausts the cursor, an error occurs, the next document isn't available
+or the context expires. Otherwise, the function returns ``true``.
+
+``TryNext()`` makes your cursor tailable. This means that the cursor
+remains open after the ``MongoClient`` exhausts it.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -219,7 +234,8 @@ following guides:
 
 - :ref:`<retrieve-golang>`
 - :ref:`<query_document_golang>`
-- :ref:`<bson-unmarshalling>`
+- :ref:`<bson-golang>`
+- :manual:`Tailable Cursors </core/tailable-cursors/>`
 
 .. - Fundamentals > BSON page
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -44,18 +44,14 @@ Each section uses the following ``cursor`` variable, which is a
 Retrieve Documents Individually
 -------------------------------
 
-To retrieve documents from your cursor individually, use the
-``Next()`` method.
+To retrieve documents from your cursor individually while blocking the
+current goroutine, use the ``Next()`` method.
 
-This method blocks the current goroutine. That means the function
-returns a document if each of the following is true:
+The method returns a document if each of the following is true:
 
 - A document is currently or will later be available
 - No errors occurred
-- The ``MongoClient`` didn't exhaust the cursor
 - The context didn't expire
-
-.. include:: /includes/fundamentals/exhausted-cursor-definition.rst
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -63,21 +59,17 @@ returns a document if each of the following is true:
    :start-after: begin cursor next
    :end-before: end cursor next
 
-Documents Only in the Cursor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Non-blocking Alternative
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-To attempt retrieving a document from your cursor, use the ``TryNext()``
-method.
+To attempt retrieving a document from your cursor without blocking the
+current goroutine, use the ``TryNext()`` method.
 
-This method is unable to block the current goroutine. That means the
-function returns a document if each of the following is true:
+The method returns a document if each of the following is true:
 
-- A document is currently available
+- A document is currently  or will later be available
 - No errors occurred
-- The ``MongoClient`` didn't exhaust the cursor
 - The context didn't expire
-
-.. include:: /includes/fundamentals/exhausted-cursor-definition.rst
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -101,16 +93,15 @@ method:
 
    If the number and size of documents returned by your query exceeds
    available application memory, your program will crash. If you except
-   a large result set, you should :ref:`consume the cursor iteratively
+   a large result set, you should :ref:`consume your cursor iteratively
    <individual-documents-golang>`.
 
 Close the Cursor
 ----------------
 
 When your application no longer needs to use a cursor, close the cursor
-with the ``Close()`` method. This method frees up your cursor's
-consumption of resources in both the client application and the 
-MongoDB server.
+with the ``Close()`` method. This method frees the resources your cursor
+consumes in both the client application and the MongoDB server.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -121,7 +112,7 @@ MongoDB server.
 .. note:: 
 
    Close the cursor when you :ref:`retrieve documents individually
-   <individual-documents-golang>` because those functions make a cursor
+   <individual-documents-golang>` because those methods make a cursor
    :manual:`tailable </core/tailable-cursors/>`.
 
 Additional Information
@@ -137,13 +128,11 @@ following guides:
 
 .. - Fundamentals > BSON page
 
-.. _cursor-api-docs-golang:
-
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-For more information on how to access a cursor's elements before the
-cursor is exhausted, see the following API Documentation:
+For more information on cursors and how to access their elements, see
+the following API Documentation:
 
 - `Cursor <{+api+}/mongo#Cursor>`__
 - `Cursor.All() <{+api+}/mongo#Cursor.All>`__

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -37,9 +37,10 @@ with the ``Find()`` function.
 Access Cursor Elements
 ----------------------
 
-You can access a cursors elements before it's exhausted. You exhaust a
-cursor when you iterate through its results and reach its last element.
-Afterwards, the cursor won't respond to functions to access its elements.
+You can access a cursors elements before it's **exhausted**. A cursor is
+exhausted when you iterate through its results and reach its last
+element. Afterwards, the cursor won't respond to functions to access its
+elements.
 
 .. important::
 
@@ -116,12 +117,12 @@ To retrive the ID of the cursor, use the ``ID()`` function.
    Include the option to set your batch size. The batch size needs to be
    a number less than or equal to the number of documents you expect to
    retrieve for a valid cursor ID. If you omit this option, set the
-   batch size to greater than the elements retrieved, or exhaust the
-   cursor, the cursor ID is ``0``.
+   batch size to greater than the elements retrieved, or the cursor is
+   exhausted, the cursor ID is ``0``.
    
    .. code-block:: go
       
-      opts := options.Find().SetBatchSize(3)
+      opts := options.Find().SetBatchSize(<a number>)
       cursor, err := coll.Find(context.TODO(), bson.D{}, opts)
       if err != nil {
          panic(err)
@@ -173,8 +174,8 @@ Next
 To block until a document is available, an error occurs, or the context
 expires, use the ``Next()`` function.
 
-The function returns ``true`` if no errors occur and you didn't exhaust
-the cursor. Otherwise, the function returns ``false``.
+The function returns ``true`` if no errors occur and the cursor isn't
+exhausted. Otherwise, the function returns ``false``.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -188,8 +189,8 @@ Attempt Next
 To attempt retriving the next document in a cursor, use the
 ``TryNext()`` function. 
 
-The function returns ``false`` if the driver exhausts the cursor, an
-error occurs, the next document isn't available or the context expires.
+The function returns ``false`` if the cursor is exhausted, an error
+occurs, the next document isn't available or the context expires.
 Otherwise, the function returns ``true``.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -18,21 +18,103 @@ Overview
 In this guide, you can learn how to access data with a **cursor**.
 
 A cursor is a mechanism that allows an application to iterate over
-database results while holding a subset of them in memory at a given
-time. The Go driver uses a cursor in some read operations to return
-matched documents in batches as opposed to all at once.
+database results while holding only a subset of them in memory at a
+given time. Read operations that match multiple documents use a cursor
+to return matched documents in batches as opposed to all at once.
 
-Retrieve Sample Data
-~~~~~~~~~~~~~~~~~~~~
+.. important::
 
-Each section assumes you retrieve all the documents in your collection
-with the ``Find()`` function.
+   A cursor is not goroutine safe. Do not use the same cursor in
+   multiple goroutines at the same time.
+
+Sample Cursor
+~~~~~~~~~~~~~
+
+The following sections use a ``cursor`` variable as shown:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
    :dedent:
    :start-after: begin find
    :end-before: end find
+
+The ``cursor`` variable is a cursor that retrieved all the documents in
+a collection with the ``Find()`` function.
+
+.. _cursor-iteration-golang:
+
+.. note::
+   
+   If you previously used the cursor to iterate some documents, the
+   driver excludes those documents when you iterate again. 
+
+Retrieve All Documents
+----------------------
+
+To populate an array with all of your query results, use the ``All()``
+method:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin cursor all
+   :end-before: end cursor all
+
+.. important:: Memory
+
+   This method crashes your application if your query retrieves a number
+   of documents larger than the size of your array. If this occurs, you
+   should :ref:`retrieve the documents individually
+   <individual-documents-golang>`.
+
+.. _individual-documents-golang:
+
+Retrieve Documents Individually
+-------------------------------
+
+To retrieve documents from your cursor individually, use the
+``Next()`` method.
+
+This method blocks the current goroutine while fetching documents from
+MongoDB. That means the function returns a document if each of the
+following is true:
+
+- A document is currently or will later be available
+- No errors occurred
+- The ``MongoClient`` didn't exhaust the cursor
+- The context didn't expire
+
+.. tip::
+
+   Iterating through your documents individually removes the possibility
+   of crashing your application. You can also access a cursors elements.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin cursor next
+   :end-before: end cursor next
+
+Documents in the Cursor
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To attempt retrieving a document from your cursor, use the ``TryNext()``
+method.
+
+This method is unable to block the current goroutine while fetching
+documents from MongoDB. That means the function returns a document if
+each of the following is true:
+
+- A document is currently available
+- No errors occurred
+- The ``MongoClient`` didn't exhaust the cursor
+- The context didn't expire
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
+   :language: go
+   :dedent:
+   :start-after: begin cursor try next
+   :end-before: end cursor try next
 
 Access Cursor Elements
 ----------------------
@@ -42,20 +124,12 @@ exhausted when the ``MongoClient`` iterates through its results and
 reaches its last element. Afterwards, the cursor won't respond to
 functions to access its elements.
 
-.. important::
-
-   A cursor is not goroutine safe. Do not use the same cursor in
-   multiple goroutines at the same time.
-
-Current Document
-~~~~~~~~~~~~~~~~
-
 When :ref:`iterating through your cursors results
 <cursor-iteration-golang>`, you can view each document as a ``BSON`` or
 Go value.
 
-BSON
-````
+BSON Document
+~~~~~~~~~~~~~
 
 To access the current document as raw ``BSON``, use the ``Current``
 property.
@@ -66,8 +140,8 @@ property.
    :start-after: begin current
    :end-before: end current
 
-Go Value
-````````
+Go Value Document
+~~~~~~~~~~~~~~~~~
 
 To access the current document as a Go value, use the ``Decode()``
 function. 
@@ -84,41 +158,20 @@ unmarshalling process without any modification.
    }
    fmt.Println(result)
 
-Remaining Batch Length
-~~~~~~~~~~~~~~~~~~~~~~
+Other Elements
+~~~~~~~~~~~~~~
 
-To retrieve the amount of documents remaining in the current batch, use
-the ``RemainingBatchLength()`` function.
+You can also retrieve the following elements:
 
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
-   :language: go
-   :dedent:
-   :start-after: begin remaining batch length
-   :end-before: end remaining batch length
+- `The number of documents remaining in a batch <{+api+}/mongo#Cursor.RemainingBatchLength>`__
+- `The cursor ID <{+api+}/mongo#Cursor.ID>`__ 
+- `The errors encountered <{+api+}/mongo#Cursor.Err>`__
 
-.. note::
+.. important:: Retrieving the Cursor ID
 
-   If the amount is ``0`` and you call the ``Next()`` or ``TryNext()``
-   function, it performs a network request to fetch the next batch.
-
-Cursor ID
-~~~~~~~~~
-
-To retrieve the ID of the cursor, use the ``ID()`` function. 
-
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
-   :language: go
-   :dedent:
-   :start-after: begin id
-   :end-before: end id
-
-.. important::
-
-   Include the option to set your batch size. The batch size needs to be
-   a number less than or equal to the number of documents you expect to
-   retrieve for a valid cursor ID. If you omit this option, set the
-   batch size to greater than the elements retrieved, or the
-   ``MongoClient`` exhausts the cursor, the cursor ID is ``0``.
+   If you want to retrieve the cursor ID, include the option to set your
+   batch size. The batch size needs to be a number less than or equal to
+   the number of documents you expect to retrieve for a valid cursor ID.
    
    .. code-block:: go
       
@@ -128,107 +181,17 @@ To retrieve the ID of the cursor, use the ``ID()`` function.
          panic(err)
       }
 
-Errors
-~~~~~~
+   If you omit this option, set the batch size to greater than the
+   elements retrieved, or the ``MongoClient`` exhausts the cursor, the
+   cursor ID is ``0``.
 
-To retrieve the last error the cursor encountered, use the ``Err()``
-function. The error is ``nil`` if no errors occurred.
+Close the Cursor
+----------------
 
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
-   :language: go
-   :dedent:
-   :start-after: begin err
-   :end-before: end err
-
-.. _cursor-iteration-golang:
-
-Usage Patterns
---------------
-
-A cursor allows you to access query results one document at a time,
-abstracting away network and caching logic. 
-
-.. note::
-   
-   If you previously used the cursor to iterate some documents, the
-   driver excludes those documents when you iterate again. 
-
-Functional Iteration
-~~~~~~~~~~~~~~~~~~~~
-
-Functional iteration functions make your cursor non-tailable, which
-means the following occurs:
-
-- The cursor automatically closes after the ``MongoClient`` exhausts it.
-- The cursor stops retrieving documents even if you insert them.
-
-All
-```
-
-To iterate through all results, use the ``All()`` function. 
-
-This function unmarshals all the documents stored in a cursor into an
-array at the same time. 
-
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
-   :language: go
-   :dedent:
-   :start-after: begin cursor all
-   :end-before: end cursor all
-
-Manual Iteration
-~~~~~~~~~~~~~~~~
-
-Manual iteration functions make your cursor tailable, which means the
-following occurs:
-
-- The cursor remains open after the ``MongoClient`` exhausts it.
-- The cursor continues to retrieve documents as you insert them.
-
-Next
-````
-
-To iterate through each result or to purposely wait for the next
-available document, use the ``Next()`` function. 
-
-.. tip::
-
-   While going through each result, you can further specify how you want
-   the documents printed though the :ref:`find operations options
-   <retrieve-options>`.
-
-This function blocks the current goroutine until a document is
-available, an error occurs, or the context expires. It returns ``true``
-if no errors occur and the ``MongoClient`` didn't exhaust the cursor.
-Otherwise, the function returns ``false``.
-   
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
-   :language: go
-   :dedent:
-   :start-after: begin cursor next
-   :end-before: end cursor next
-
-Attempt Next
-````````````
-
-Alternatively, you can use the ``TryNext()`` function.
-
-This function attempts to retrieve the next document in a cursor. It's
-non-blocking, which means it returns ``false`` if the ``MongoClient``
-exhausts the cursor, an error occurs, the next document isn't available
-or the context expires. Otherwise, the function returns ``true``.
-
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
-   :language: go
-   :dedent:
-   :start-after: begin cursor try next
-   :end-before: end cursor try next
-
-Cursor Cleanup
---------------
-
-To free up a cursor's consumption of resources in both the client
-application and the MongoDB server, use the ``Close()`` function. 
+When your application no longer needs to use a cursor, close the cursor
+with the ``Close()`` method. This method free's up your cursor's
+consumption of resources in both the client application and the 
+MongoDB server.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -245,7 +208,6 @@ following guides:
 - :ref:`<retrieve-golang>`
 - :ref:`<query_document_golang>`
 - :ref:`<bson-golang>`
-- :manual:`Tailable Cursors </core/tailable-cursors/>`
 
 .. - Fundamentals > BSON page
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -19,14 +19,14 @@ In this guide, you can learn how to access data with a **cursor**.
 
 A cursor is a mechanism that allows an application to iterate over
 database results while holding a subset of them in memory at a given
-time. The Go driver uses a cursor in read operations to return matched
-documents in batches as opposed to all at once.
+time. The Go driver uses a cursor in some read operations to return
+matched documents in batches as opposed to all at once.
 
 Retrieve Sample Data
 ~~~~~~~~~~~~~~~~~~~~
 
 Each section assumes you retrieve all the documents in your collection
-with the following snippet:
+with the ``Find()`` function.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -43,8 +43,8 @@ Afterwards, the cursor won't respond to functions to access its elements.
 
 .. important::
 
-   A cursor is not goroutine safe. You should not use the same cursor in
-   multiple goroutines at the same time. 
+   A cursor is not goroutine safe. Do not use the same cursor in
+   multiple goroutines at the same time.
 
 Current Document
 ~~~~~~~~~~~~~~~~
@@ -89,16 +89,16 @@ Remaining Batch Length
 To retrieve the amount of doucments remaining in the current batch, use
 the ``RemainingBatchLength()`` function.
 
-.. note::
-
-   If the amount is ``0``, making a call to ``Next()`` or ``TryNext()``
-   does a network request to fetch the next batch. 
-
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
    :dedent:
    :start-after: begin remaining batch length
    :end-before: end remaining batch length
+
+.. note::
+
+   If the amount is ``0`` and you call the ``Next()`` or ``TryNext()``
+   function, it performs a network request to fetch the next batch.
 
 Cursor ID
 ~~~~~~~~~
@@ -113,11 +113,11 @@ To retrive the ID of the cursor, use the ``ID()`` function.
 
 .. important::
 
-   Include a ``FindOptions.SetBatchSize()`` with a batch size less than or
-   equal to the number of documents you expect to retrieve for a valid
-   cursor ID. If you omit this option, set the batch size to greater than
-   the elements retrieved, or exhaust the cursor, the cursor ID is
-   ``0``.
+   Include the option to set your batch size. The batch size needs to be
+   a number less than or equal to the number of documents you expect to
+   retrieve for a valid cursor ID. If you omit this option, set the
+   batch size to greater than the elements retrieved, or exhaust the
+   cursor, the cursor ID is ``0``.
    
    .. code-block:: go
       
@@ -150,8 +150,7 @@ abstracting away network and caching logic.
 .. note::
    
    If you previously used the cursor to iterate some documents, the
-   driver excluses those documents in its results when you iterate
-   again. 
+   driver excluses those documents when you iterate again. 
 
 All
 ~~~
@@ -218,6 +217,7 @@ For more information on the operations discussed in this guide, see the
 following guides:
 
 - :ref:`<retrieve-golang>`
+- :ref:`<query_document_golang>`
 - :ref:`<bson-unmarshalling>`
 
 .. - Fundamentals > BSON page
@@ -233,7 +233,7 @@ guide, see the following API Documentation:
 - `Cursor.RemainingBatchLength() <{+api+}/mongo#Cursor.RemainingBatchLength>`__
 - `Cursor.ID() <{+api+}/mongo#Cursor.ID>`__
 - `Cursor.Err() <{+api+}/mongo#Cursor.Err>`__
-- `Cursor.All() <{+api+}/mongo#Cursor.All`__
+- `Cursor.All() <{+api+}/mongo#Cursor.All>`__
 - `Cursor.Next() <{+api+}/mongo#Cursor.Next>`__
 - `Cursor.TryNext() <{+api+}/mongo#Cursor.TryNext>`__
 - `Cursor.Close() <{+api+}/mongo#Cursor.Close>`__

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -25,8 +25,8 @@ to return those documents in batches as opposed to all at once.
 Sample Cursor
 ~~~~~~~~~~~~~
 
-The following sections use a ``cursor`` variable, which is a cursor that
-retrieved all the documents in a collection with the ``Find()`` function.
+Each section uses the following ``cursor`` variable, which is a
+``Cursor`` struct that contains all the documents in a collection:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -38,24 +38,6 @@ retrieved all the documents in a collection with the ``Find()`` function.
 
    A cursor is not goroutine safe. Do not use the same cursor in
    multiple goroutines at the same time.
-
-Retrieve All Documents
-----------------------
-
-To populate an array with all of your query results, use the ``All()``
-method:
-
-.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
-   :language: go
-   :dedent:
-   :start-after: begin cursor all
-   :end-before: end cursor all
-
-.. important:: Memory
-
-   This method crashes your application if your query retrieves a number
-   of documents larger than the size of your array. If this occurs,
-   :ref:`retrieve the documents individually <individual-documents-golang>`.
 
 .. _individual-documents-golang:
 
@@ -73,22 +55,13 @@ returns a document if each of the following is true:
 - The ``MongoClient`` didn't exhaust the cursor
 - The context didn't expire
 
-.. tip::
-
-   Iterating through your documents individually removes the possibility
-   of crashing your application and allows you to :ref:`access a cursors
-   elements <cursor-elements-golang>`.
+.. include:: /includes/fundamentals/exhausted-cursor-definition.rst
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
    :dedent:
    :start-after: begin cursor next
    :end-before: end cursor next
-
-.. note::
-   
-   If you previously used the cursor to iterate some documents, the
-   driver excludes those documents when you iterate again. 
 
 Documents Only in the Cursor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -104,93 +77,37 @@ function returns a document if each of the following is true:
 - The ``MongoClient`` didn't exhaust the cursor
 - The context didn't expire
 
+.. include:: /includes/fundamentals/exhausted-cursor-definition.rst
+
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
    :dedent:
    :start-after: begin cursor try next
    :end-before: end cursor try next
 
-.. note::
-   
-   If you previously used the cursor to iterate some documents, the
-   driver excludes those documents when you iterate again. 
-
-.. _cursor-elements-golang:
-
-Access Cursor Elements
+Retrieve All Documents
 ----------------------
 
-You can access a cursors elements before it's **exhausted**. A cursor is
-exhausted when the ``MongoClient`` iterates through its results and
-reaches its last element. Afterwards, the cursor won't respond to
-functions to access its elements.
-
-When :ref:`individually retrieving your cursors results
-<individual-documents-golang>`, you can view each document as a ``BSON`` or
-Go value.
-
-BSON Document
-~~~~~~~~~~~~~
-
-To access the current document as raw ``BSON``, use the ``Current``
-property.
+To populate an array with all of your query results, use the ``All()``
+method:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
    :dedent:
-   :start-after: begin current
-   :end-before: end current
+   :start-after: begin cursor all
+   :end-before: end cursor all
 
-Go Value Document
-~~~~~~~~~~~~~~~~~
+.. important:: Memory
 
-To access the current document as a Go value, use the ``Decode()``
-function. 
-
-This function unmarshals the current document into the :ref:`BSON
-interface <bson-types>` you specify. It returns any errors from the
-unmarshalling process without any modification.
-
-.. code-block:: go
-
-   var result bson.D
-   if err := cursor.Decode(&result); err != nil {
-      log.Fatal(err)
-   }
-   fmt.Println(result)
-
-Other Elements
-~~~~~~~~~~~~~~
-
-You can also retrieve the following elements:
-
-- `The number of documents remaining in the batch. <{+api+}/mongo#Cursor.RemainingBatchLength>`__
-- `The cursor ID. <{+api+}/mongo#Cursor.ID>`__ 
-- `The cursor errors encountered. <{+api+}/mongo#Cursor.Err>`__
-
-.. important:: Retrieving the Cursor ID
-
-   If you want to retrieve the cursor ID, include the option to set your
-   batch size. The batch size needs to be a number less than or equal to
-   the number of documents you expect to retrieve.
-   
-   .. code-block:: go
-      
-      opts := options.Find().SetBatchSize(<a number>)
-      cursor, err := coll.Find(context.TODO(), bson.D{}, opts)
-      if err != nil {
-         panic(err)
-      }
-
-   If you omit this option, set the batch size to a number greater than
-   the elements retrieved, or the ``MongoClient`` exhausts the cursor,
-   the cursor ID is ``0``.
+   If your query retrieves a number of documents larger than the size of
+   your array, this method crashes your application. If this occurs, 
+   :ref:`retrieve the documents individually <individual-documents-golang>`.
 
 Close the Cursor
 ----------------
 
 When your application no longer needs to use a cursor, close the cursor
-with the ``Close()`` method. This method free's up your cursor's
+with the ``Close()`` method. This method frees up your cursor's
 consumption of resources in both the client application and the 
 MongoDB server.
 
@@ -202,9 +119,9 @@ MongoDB server.
 
 .. note:: 
 
-   Close the cursor when you retrieve documents individually because
-   those functions make a cursor :manual:`tailable
-   </core/tailable-cursors/>`.
+   Close the cursor when you :ref:`retrieve documents individually
+   <individual-documents-golang>` because those functions make a cursor
+   :manual:`tailable </core/tailable-cursors/>`.
 
 Additional Information
 ----------------------
@@ -222,8 +139,8 @@ following guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-For more information on any of the functions or types discussed in this
-guide, see the following API Documentation:
+For more information on how to access a cursor's elements before the
+cursor is exhausted, see the following API Documentation:
 
 - `Cursor <{+api+}/mongo#Cursor>`__
 - `Cursor.All() <{+api+}/mongo#Cursor.All>`__

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -25,16 +25,14 @@ to return those documents in batches as opposed to all at once.
 Sample Cursor
 ~~~~~~~~~~~~~
 
-The following sections use a ``cursor`` variable as shown:
+The following sections use a ``cursor`` variable, which is a cursor that
+retrieved all the documents in a collection with the ``Find()`` function.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
    :dedent:
    :start-after: begin find
    :end-before: end find
-
-The ``cursor`` variable is a cursor that retrieved all the documents in
-a collection with the ``Find()`` function.
 
 .. important::
 
@@ -67,9 +65,8 @@ Retrieve Documents Individually
 To retrieve documents from your cursor individually, use the
 ``Next()`` method.
 
-This method blocks the current goroutine while fetching documents from
-MongoDB. That means the function returns a document if each of the
-following is true:
+This method blocks the current goroutine. That means the function
+returns a document if each of the following is true:
 
 - A document is currently or will later be available
 - No errors occurred
@@ -79,7 +76,7 @@ following is true:
 .. tip::
 
    Iterating through your documents individually removes the possibility
-   of crashing your application and allows you to access a :ref:`cursors
+   of crashing your application and allows you to :ref:`access a cursors
    elements <cursor-elements-golang>`.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
@@ -99,9 +96,8 @@ Documents Only in the Cursor
 To attempt retrieving a document from your cursor, use the ``TryNext()``
 method.
 
-This method is unable to block the current goroutine while fetching
-documents from MongoDB. That means the function returns a document if
-each of the following is true:
+This method is unable to block the current goroutine. That means the
+function returns a document if each of the following is true:
 
 - A document is currently available
 - No errors occurred
@@ -186,9 +182,9 @@ You can also retrieve the following elements:
          panic(err)
       }
 
-   If you omit this option, set the batch size to greater than the
-   elements retrieved, or the ``MongoClient`` exhausts the cursor, the
-   cursor ID is ``0``.
+   If you omit this option, set the batch size to a number greater than
+   the elements retrieved, or the ``MongoClient`` exhausts the cursor,
+   the cursor ID is ``0``.
 
 Close the Cursor
 ----------------
@@ -204,6 +200,12 @@ MongoDB server.
    :start-after: begin close
    :end-before: end close
 
+.. note:: 
+
+   Close the cursor when you retrieve documents individually because
+   those functions make a cursor :manual:`tailable
+   </core/tailable-cursors/>`.
+
 Additional Information
 ----------------------
 
@@ -213,6 +215,7 @@ following guides:
 - :ref:`<retrieve-golang>`
 - :ref:`<query_document_golang>`
 - :ref:`<bson-golang>`
+- :manual:`Tailable Cursors </core/tailable-cursors/>`
 
 .. - Fundamentals > BSON page
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -99,9 +99,10 @@ method:
 
 .. important:: Memory
 
-   If your query retrieves a number of documents larger than the size of
-   your array, this method crashes your application. If this occurs, 
-   :ref:`retrieve the documents individually <individual-documents-golang>`.
+   If the number and size of documents returned by your query exceeds
+   available application memory, your program will crash. If you except
+   a large result set, you should :ref:`consume the cursor iteratively
+   <individual-documents-golang>`.
 
 Close the Cursor
 ----------------
@@ -135,6 +136,8 @@ following guides:
 - :manual:`Tailable Cursors </core/tailable-cursors/>`
 
 .. - Fundamentals > BSON page
+
+.. _cursor-api-docs-golang:
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -67,7 +67,7 @@ To attempt retrieving a document from a :manual:`tailable cursor
 
 The method returns a document if each of the following is true:
 
-- A document is currently or will later be available
+- A document is currently available
 - No errors occurred
 - The context didn't expire
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -156,16 +156,19 @@ abstracting away network and caching logic.
 Functional Iteration
 ~~~~~~~~~~~~~~~~~~~~
 
-To iterate through all results, use the ``All()`` function. 
-
-This function unmarshals all the documents stored in a cursor into an
-array at the same time. 
-
-The ``All()`` function makes your cursor non-tailable, which
+Functional iteration functions make your cursor non-tailable, which
 means the following occurs:
 
 - The cursor automatically closes after the ``MongoClient`` exhausts it.
 - The cursor stops retrieving documents even if you insert them.
+
+All
+```
+
+To iterate through all results, use the ``All()`` function. 
+
+This function unmarshals all the documents stored in a cursor into an
+array at the same time. 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -191,7 +194,8 @@ available document, use the ``Next()`` function.
 .. tip::
 
    While going through each result, you can further specify how you want
-   the documents printed though the find operations options. 
+   the documents printed though the :ref:`find operations options
+   <retrieve-options>`.
 
 This function blocks the current goroutine until a document is
 available, an error occurs, or the context expires. It returns ``true``

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -20,12 +20,7 @@ In this guide, you can learn how to access data with a **cursor**.
 A cursor is a mechanism that allows an application to iterate over
 database results while holding only a subset of them in memory at a
 given time. Read operations that match multiple documents use a cursor
-to return matched documents in batches as opposed to all at once.
-
-.. important::
-
-   A cursor is not goroutine safe. Do not use the same cursor in
-   multiple goroutines at the same time.
+to return those documents in batches as opposed to all at once.
 
 Sample Cursor
 ~~~~~~~~~~~~~
@@ -41,12 +36,10 @@ The following sections use a ``cursor`` variable as shown:
 The ``cursor`` variable is a cursor that retrieved all the documents in
 a collection with the ``Find()`` function.
 
-.. _cursor-iteration-golang:
+.. important::
 
-.. note::
-   
-   If you previously used the cursor to iterate some documents, the
-   driver excludes those documents when you iterate again. 
+   A cursor is not goroutine safe. Do not use the same cursor in
+   multiple goroutines at the same time.
 
 Retrieve All Documents
 ----------------------
@@ -63,9 +56,8 @@ method:
 .. important:: Memory
 
    This method crashes your application if your query retrieves a number
-   of documents larger than the size of your array. If this occurs, you
-   should :ref:`retrieve the documents individually
-   <individual-documents-golang>`.
+   of documents larger than the size of your array. If this occurs,
+   :ref:`retrieve the documents individually <individual-documents-golang>`.
 
 .. _individual-documents-golang:
 
@@ -87,7 +79,8 @@ following is true:
 .. tip::
 
    Iterating through your documents individually removes the possibility
-   of crashing your application. You can also access a cursors elements.
+   of crashing your application and allows you to access a :ref:`cursors
+   elements <cursor-elements-golang>`.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -95,8 +88,13 @@ following is true:
    :start-after: begin cursor next
    :end-before: end cursor next
 
-Documents in the Cursor
-~~~~~~~~~~~~~~~~~~~~~~~
+.. note::
+   
+   If you previously used the cursor to iterate some documents, the
+   driver excludes those documents when you iterate again. 
+
+Documents Only in the Cursor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To attempt retrieving a document from your cursor, use the ``TryNext()``
 method.
@@ -116,6 +114,13 @@ each of the following is true:
    :start-after: begin cursor try next
    :end-before: end cursor try next
 
+.. note::
+   
+   If you previously used the cursor to iterate some documents, the
+   driver excludes those documents when you iterate again. 
+
+.. _cursor-elements-golang:
+
 Access Cursor Elements
 ----------------------
 
@@ -124,8 +129,8 @@ exhausted when the ``MongoClient`` iterates through its results and
 reaches its last element. Afterwards, the cursor won't respond to
 functions to access its elements.
 
-When :ref:`iterating through your cursors results
-<cursor-iteration-golang>`, you can view each document as a ``BSON`` or
+When :ref:`individually retrieving your cursors results
+<individual-documents-golang>`, you can view each document as a ``BSON`` or
 Go value.
 
 BSON Document
@@ -163,15 +168,15 @@ Other Elements
 
 You can also retrieve the following elements:
 
-- `The number of documents remaining in a batch <{+api+}/mongo#Cursor.RemainingBatchLength>`__
-- `The cursor ID <{+api+}/mongo#Cursor.ID>`__ 
-- `The errors encountered <{+api+}/mongo#Cursor.Err>`__
+- `The number of documents remaining in the batch. <{+api+}/mongo#Cursor.RemainingBatchLength>`__
+- `The cursor ID. <{+api+}/mongo#Cursor.ID>`__ 
+- `The cursor errors encountered. <{+api+}/mongo#Cursor.Err>`__
 
 .. important:: Retrieving the Cursor ID
 
    If you want to retrieve the cursor ID, include the option to set your
    batch size. The batch size needs to be a number less than or equal to
-   the number of documents you expect to retrieve for a valid cursor ID.
+   the number of documents you expect to retrieve.
    
    .. code-block:: go
       
@@ -218,11 +223,11 @@ For more information on any of the functions or types discussed in this
 guide, see the following API Documentation:
 
 - `Cursor <{+api+}/mongo#Cursor>`__
+- `Cursor.All() <{+api+}/mongo#Cursor.All>`__
+- `Cursor.Next() <{+api+}/mongo#Cursor.Next>`__
+- `Cursor.TryNext() <{+api+}/mongo#Cursor.TryNext>`__
 - `Cursor.Decode() <{+api+}/mongo#Cursor.Decode>`__
 - `Cursor.RemainingBatchLength() <{+api+}/mongo#Cursor.RemainingBatchLength>`__
 - `Cursor.ID() <{+api+}/mongo#Cursor.ID>`__
 - `Cursor.Err() <{+api+}/mongo#Cursor.Err>`__
-- `Cursor.All() <{+api+}/mongo#Cursor.All>`__
-- `Cursor.Next() <{+api+}/mongo#Cursor.Next>`__
-- `Cursor.TryNext() <{+api+}/mongo#Cursor.TryNext>`__
 - `Cursor.Close() <{+api+}/mongo#Cursor.Close>`__

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -159,9 +159,13 @@ Functional Iteration
 To iterate through all results, use the ``All()`` function. 
 
 This function unmarshals all the documents stored in a cursor into an
-array at the same time. ``All()`` makes your cursor non-tailable. This
-means that the cursor automatically closes after the ``MongoClient``
-exhausts it.
+array at the same time. 
+
+The ``All()`` function makes your cursor non-tailable, which
+means the following occurs:
+
+- The cursor automatically closes after the ``MongoClient`` exhausts it.
+- The cursor stops retrieving documents even if you insert them.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
@@ -171,6 +175,15 @@ exhausts it.
 
 Manual Iteration
 ~~~~~~~~~~~~~~~~
+
+Manual iteration functions make your cursor tailable, which means the
+following occurs:
+
+- The cursor remains open after the ``MongoClient`` exhausts it.
+- The cursor continues to retrieve documents as you insert them.
+
+Next
+````
 
 To iterate through each result or to purposely wait for the next
 available document, use the ``Next()`` function. 
@@ -184,11 +197,7 @@ This function blocks the current goroutine until a document is
 available, an error occurs, or the context expires. It returns ``true``
 if no errors occur and the ``MongoClient`` didn't exhaust the cursor.
 Otherwise, the function returns ``false``.
-
-``Next()`` makes your cursor tailable. This means that the cursor
-remains open after the ``MongoClient`` exhausts it.
    
-
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go
    :dedent:
@@ -204,9 +213,6 @@ This function attempts to retrieve the next document in a cursor. It's
 non-blocking, which means it returns ``false`` if the ``MongoClient``
 exhausts the cursor, an error occurs, the next document isn't available
 or the context expires. Otherwise, the function returns ``true``.
-
-``TryNext()`` makes your cursor tailable. This means that the cursor
-remains open after the ``MongoClient`` exhausts it.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/cursor.go
    :language: go

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -65,6 +65,8 @@ filter as a ``SingleResult`` type.
 To learn how to access data in a ``SingleResult`` see the :ref:`BSON
 <bson-unmarshalling>` guide.
 
+.. _retrieve-options:
+
 Modify Behavior
 ~~~~~~~~~~~~~~~
 

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -1,3 +1,5 @@
+.. _retrieve-golang:
+
 ==============
 Retrieve Data
 ==============
@@ -51,8 +53,7 @@ The ``Find()`` function expects you to pass a ``Context`` type and a
 query filter. The function returns *all* documents that match the filter
 as a ``Cursor`` type.
 
-.. To learn how to access data in a cursor, see the :doc:`Cursor
-.. </fundamentals/crud/read-operations/cursor>` guide.
+To learn how to access data in a cursor, see the :ref:`<cursor-golang>` guide.
 
 Find One Document
 ~~~~~~~~~~~~~~~~~
@@ -174,8 +175,7 @@ The function returns the resulting documents in a ``Cursor`` type. If
 you omit the :manual:`$match </reference/operator/aggregation/match/#mongodb-pipeline-pipe.-match>`
 stage, the pipeline proceeds using all documents in the collection.
 
-.. To learn how to access data in a cursor, see the :doc:`Cursor
-.. </fundamentals/crud/read-operations/cursor>` guide.
+To learn how to access data in a cursor, see the :ref:`<cursor-golang>` guide.
 
 Modify Behavior
 ~~~~~~~~~~~~~~~
@@ -271,6 +271,7 @@ For more information about the operations mentioned, see the following
 guides:
 
 - :doc:`Specify a Query </fundamentals/crud/query-document>`
+- :ref:`<cursor-golang>`
 - :doc:`Skip Returned Results </fundamentals/crud/read-operations/skip>`
 - :doc:`Sort Results </fundamentals/crud/read-operations/sort>`
 - :doc:`Limit the Number of Returned Results </fundamentals/crud/read-operations/limit>`

--- a/source/includes/fundamentals/code-snippets/CRUD/cursor.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/cursor.go
@@ -139,6 +139,9 @@ func main() {
 			if err := cursor.Err(); err != nil {
 				log.Fatal(err)
 			}
+			if cursor.ID() == 0 {
+				break
+			}
 		}
 		// end cursor try next
 	}

--- a/source/includes/fundamentals/code-snippets/CRUD/cursor.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/cursor.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	var uri string
-	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
+	if uri = os.Getenv("MONGODB_URI"); uri == "" {
 		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
 	}
 
@@ -138,9 +138,6 @@ func main() {
 
 			if err := cursor.Err(); err != nil {
 				log.Fatal(err)
-			}
-			if cursor.ID() == 0 {
-				break
 			}
 		}
 		// end cursor try next

--- a/source/includes/fundamentals/code-snippets/CRUD/cursor.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/cursor.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	var uri string
+	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
+		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+	}
+
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			panic(err)
+		}
+	}()
+
+	client.Database("tea").Collection("ratings").Drop(context.TODO())
+
+	coll := client.Database("tea").Collection("ratings")
+	docs := []interface{}{
+		bson.D{{"type", "Masala"}, {"rating", 10}},
+		bson.D{{"type", "Earl Grey"}, {"rating", 5}},
+		bson.D{{"type", "Assam"}, {"rating", 7}},
+	}
+
+	result, err := coll.InsertMany(context.TODO(), docs)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
+
+	fmt.Println("Cursor Elements:")
+	{
+		opts := options.Find().SetBatchSize(3)
+		cursor, err := coll.Find(context.TODO(), bson.D{}, opts)
+		if err != nil {
+			panic(err)
+		}
+
+		// begin close
+		defer cursor.Close(context.TODO())
+		// end close
+		
+		for cursor.Next(context.TODO()) {
+			// begin current
+			fmt.Println(cursor.Current)
+			// end current
+			// begin remaining batch length
+			fmt.Println(cursor.RemainingBatchLength())
+			// end remaining batch length
+			// begin id
+			fmt.Println(cursor.ID())
+			// end id
+			// begin err
+			fmt.Println(cursor.Err())
+			// end err
+		}
+	}
+
+	fmt.Println("Cursor.All():")
+	{
+		// begin find
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+		// end find
+
+		defer cursor.Close(context.TODO())
+		
+		// begin cursor all
+		var results []bson.D
+		if err = cursor.All(context.TODO(), &results); err != nil {
+			panic(err)
+		}
+		for _, result := range results {
+			fmt.Println(result)
+		}
+		// end cursor all
+	}
+
+	fmt.Println("Cursor.Next():")
+	{
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+
+		defer cursor.Close(context.TODO())
+
+		// begin cursor next
+		for cursor.Next(context.TODO()) {
+			var result bson.D
+			if err := cursor.Decode(&result); err != nil {
+				log.Fatal(err)
+			}
+			fmt.Println(result)
+		}
+		if err := cursor.Err(); err != nil {
+			log.Fatal(err)
+		}
+		// end cursor next
+	}
+
+	fmt.Println("Cursor.TryNext():")
+	{
+		cursor, err := coll.Find(context.TODO(), bson.D{})
+		if err != nil {
+			panic(err)
+		}
+
+		defer cursor.Close(context.TODO())
+
+		// begin cursor try next
+		for {
+			if cursor.TryNext(context.TODO()) {
+				var result bson.D
+				if err := cursor.Decode(&result); err != nil {
+					log.Fatal(err)
+				}
+				fmt.Println(result)
+				continue
+			}
+
+			if err := cursor.Err(); err != nil {
+				log.Fatal(err)
+			}
+			if cursor.ID() == 0 {
+				break
+			}
+		}
+		// end cursor try next
+	}
+}

--- a/source/includes/fundamentals/exhausted-cursor-definition.rst
+++ b/source/includes/fundamentals/exhausted-cursor-definition.rst
@@ -2,5 +2,4 @@
 
    A cursor is exhausted when the ``MongoClient`` iterates through its
    results and reaches its last element. Afterwards, the cursor won't
-   respond to functions to access its elements.
-   
+   respond to functions :ref:`to access its elements <cursor-api-docs-golang>`.

--- a/source/includes/fundamentals/exhausted-cursor-definition.rst
+++ b/source/includes/fundamentals/exhausted-cursor-definition.rst
@@ -1,5 +1,0 @@
-.. note:: 
-
-   A cursor is exhausted when the ``MongoClient`` iterates through its
-   results and reaches its last element. Afterwards, the cursor won't
-   respond to functions :ref:`to access its elements <cursor-api-docs-golang>`.

--- a/source/includes/fundamentals/exhausted-cursor-definition.rst
+++ b/source/includes/fundamentals/exhausted-cursor-definition.rst
@@ -1,0 +1,6 @@
+.. note:: 
+
+   A cursor is exhausted when the ``MongoClient`` iterates through its
+   results and reaches its last element. Afterwards, the cursor won't
+   respond to functions to access its elements.
+   


### PR DESCRIPTION
## Pull Request Info

Added the Fundamentals > CRUD > Read Operations > Access Data from a Cursor page.

This page covers all the functions you can use to access a cursors elements and ways to iterate through a cursor.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13833

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61aa5c2f5314b0809f18a63b

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-13833-CRUDCursor/fundamentals/crud/read-operations/cursor/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [x] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [x] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
