### PR TITLE
DOCSP-19598: update compatibility table for server 5.1

### DIFF
--- a/source/includes/mongodb-compatibility-table-go.rst
+++ b/source/includes/mongodb-compatibility-table-go.rst
@@ -4,6 +4,7 @@
    :class: compatibility-large
 
    * - Go Driver Version
+     - MongoDB 5.1
      - MongoDB 5.0
      - MongoDB 4.4
      - MongoDB 4.2
@@ -15,6 +16,7 @@
      - MongoDB 2.6
 
    * - 1.7
+     -
      - ✓
      - ✓
      - ✓
@@ -26,6 +28,7 @@
      - ✓
 
    * - 1.6
+     -
      - ✓ [#go-1.6-driver-support]_
      - ✓
      - ✓
@@ -35,8 +38,9 @@
      - ✓
      - ✓
      - ✓
-   
+
    * - 1.5
+     -
      -
      - ✓
      - ✓
@@ -48,6 +52,7 @@
      - ✓
 
    * - 1.4
+     -
      -
      - ✓
      - ✓
@@ -61,6 +66,7 @@
    * - 1.3
      -
      -
+     -
      - ✓
      - ✓
      - ✓
@@ -72,6 +78,7 @@
    * - 1.2
      -
      -
+     -
      - ✓
      - ✓
      - ✓
@@ -81,6 +88,7 @@
      - ✓
 
    * - 1.1
+     -
      -
      -
      - ✓
@@ -95,6 +103,7 @@
      -
      -
      -
+     -
      - ✓
      - ✓
      - ✓
@@ -103,4 +112,4 @@
      - ✓
 
 .. [#go-1.6-driver-support] The 1.6 driver does not support snapshot reads on secondaries. For more
-   information, see the `MongoDB Server version 5.0 release notes <https://docs.mongodb.com/v5.0/release-notes/5.0/#snapshots>`__. 
+   information, see the `MongoDB Server version 5.0 release notes <https://docs.mongodb.com/v5.0/release-notes/5.0/#snapshots>`__.


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19598

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=618aa4d7c13055282d6b198f

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-19598-compat-5.1/compatibility/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
