### PR TITLE
Bump api links to 1.8.4

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -1,0 +1,22 @@
+name: Link Checker
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Install checker tool
+        run: go install github.com/terakilobyte/checker@latest
+
+      - name: Run checker tool
+        run: git diff --name-only HEAD^..HEAD | tr "\n" "," | xargs checker --changes

--- a/snooty.toml
+++ b/snooty.toml
@@ -12,7 +12,7 @@ intersphinx = [
 ]
 
 [constants]
-docs-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
-version = "v1.8.0" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
+doc,-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
+version = "v1.8.4" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
 example = "https://raw.githubusercontent.com/mongodb/docs-golang/{+docs-branch+}/source/includes/usage-examples/code-snippets"
 api = "https://pkg.go.dev/go.mongodb.org/mongo-driver@{+version+}"

--- a/snooty.toml
+++ b/snooty.toml
@@ -12,7 +12,7 @@ intersphinx = [
 ]
 
 [constants]
-doc,-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
+doc-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
 version = "v1.8.4" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
 example = "https://raw.githubusercontent.com/mongodb/docs-golang/{+docs-branch+}/source/includes/usage-examples/code-snippets"
 api = "https://pkg.go.dev/go.mongodb.org/mongo-driver@{+version+}"

--- a/snooty.toml
+++ b/snooty.toml
@@ -12,7 +12,7 @@ intersphinx = [
 ]
 
 [constants]
-doc-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
+docs-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
 version = "v1.8.4" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
 example = "https://raw.githubusercontent.com/mongodb/docs-golang/{+docs-branch+}/source/includes/usage-examples/code-snippets"
 api = "https://pkg.go.dev/go.mongodb.org/mongo-driver@{+version+}"

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -32,7 +32,7 @@ snippet:
    :end-before: end insertDocs
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
-   
+
 Each document contains a rating for a type of tea, which corresponds to
 the ``type`` and ``rating`` fields.
 
@@ -55,7 +55,7 @@ Parameters
 
 The ``DeleteOne()`` and ``DeleteMany()`` functions expect you to pass a
 ``Context`` type and a ``non-nil`` query filter specifying which
-documents to match. 
+documents to match.
 
 They both optionally take a ``DeleteOptions`` type as a third parameter,
 which represents options you can use to configure the delete operation.
@@ -72,12 +72,12 @@ following functions:
    * - Function
      - Description
 
-   * - ``SetHint()`` 
-     - | The index to use to scan for documents to delete. 
+   * - ``SetHint()``
+     - | The index to use to scan for documents to delete.
        | Default: ``nil``
 
    * - ``SetCollation()``
-     - | The type of language collation to use when sorting results.  
+     - | The type of language collation to use when sorting results.
        | Default: ``nil``
 
 Return Value
@@ -92,7 +92,7 @@ Example
 ```````
 
 The following example performs the following with the ``DeleteMany()``
-function: 
+function:
 
 - Matches and deletes documents where the ``rating`` is greater than ``8``
 - Specifies the function to use the ``_id`` as the index
@@ -144,5 +144,5 @@ guide, see the following API Documentation:
 
 - `DeleteOne() <{+api+}/mongo#Collection.DeleteOne>`__
 - `DeleteMany() <{+api+}/mongo#Collection.DeleteMany>`__
-- `DeleteOptions <{+api+}/options#DeleteOptions>`__
+- `DeleteOptions <{+api+}/mongo/options#DeleteOptions>`__
 - `DeleteResult <{+api+}/mongo#DeleteResult>`__


### PR DESCRIPTION
## Pull Request Info

Bump API links to 1.8.4

### Issue JIRA link:
N/A

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=622017109c4c7f6bfbe3335d

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/golang/docsworker-xlarge/1.8.4/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
