### PR TITLE
fix broken api link

### DIFF
--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -144,5 +144,5 @@ guide, see the following API Documentation:
 
 - `DeleteOne() <{+api+}/mongo#Collection.DeleteOne>`__
 - `DeleteMany() <{+api+}/mongo#Collection.DeleteMany>`__
-- `DeleteOptions <{+api+}/mongo/options#DeleteOptions>`__
+- `DeleteOptions <{+api+}/mongo#options#DeleteOptions>`__
 - `DeleteResult <{+api+}/mongo#DeleteResult>`__


### PR DESCRIPTION
## Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

### Issue JIRA link:
N/A

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=623c8f110ab54725f1d5afea

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/fix-links/fundamentals/crud/write-operations/delete/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [x] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
