### PR TITLE
DOCS-15247: Go Quick Start should mention installing godotenv

### DIFF
--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -39,6 +39,18 @@ Use ``go get`` to add the Go driver as a dependency.
 
    go get go.mongodb.org/mongo-driver/mongo
 
+Add Other Dependencies
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``go get`` to add any additional dependencies. This Quick Start
+uses the ``godotenv`` package to read a MongoDB connection string
+from an environment variable to avoid embedding credentials within
+source code.
+
+.. code-block:: shell
+
+   go get github.com/joho/godotenv
+
 Create a MongoDB Cluster
 ------------------------
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browseDOCS-15247

[Preview](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/stennie-DOCS-15247/quick-start/#add-other-dependencies)

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
