### PR TITLE
DOCSP-21977 update api docs version

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -16,6 +16,6 @@ sharedinclude_root = "https://raw.githubusercontent.com/10gen/docs-shared/main/"
 [constants]
 driver-long = "MongoDB Go Driver"
 docs-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
-version = "v1.7.2" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
+version = "v1.7.6" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
 example = "https://raw.githubusercontent.com/mongodb/docs-golang/{+docs-branch+}/source/includes/usage-examples/code-snippets"
 api = "https://pkg.go.dev/go.mongodb.org/mongo-driver@{+version+}"


### PR DESCRIPTION
# Pull Request Info

Updated api docs version to 1.7.6

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-21977>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-21977/#api>

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Did you run a spell-check?
- [X] Did you run a grammar-check?
- [X] Are all the links working?
