### PR TITLE
DOCSP-21849 dot notation and wording change

### DIFF
--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -40,7 +40,7 @@ type. The ``Client`` type specifies the mechanism and credentials to use
 as connection options in a `Credential <{+api+}/mongo/options#Credential>`__
 type . To configure these options, pass a ``Credential`` type to the
 `SetAuth() <{+api+}/mongo/options#ClientOptions.SetAuth>`__
-function of the `ClientOptions <{+api+}/mongo/options#ClientOptions>`__
+method of the `ClientOptions <{+api+}/mongo/options#ClientOptions>`__
 type.
 
 The following sections demonstrate this process with the five

--- a/source/fundamentals/context.txt
+++ b/source/fundamentals/context.txt
@@ -17,14 +17,14 @@ Overview
 
 The {+driver-long+} uses the `context package
 <https://pkg.go.dev/context>`__ from Go's standard library to allow
-applications to signal timeouts and cancellations for any **blocking function**
-call. A blocking function relies on an external event, such as a network
+applications to signal timeouts and cancellations for any **blocking method**
+call. A blocking method relies on an external event, such as a network
 input or output, to proceed with its task.
 
-An example of a blocking function in the Go Driver is the ``Insert()``
-function. If you want to perform an insert operation on a ``Collection``
+An example of a blocking method in the Go Driver is the ``Insert()``
+method. If you want to perform an insert operation on a ``Collection``
 within 10 seconds, you can use a Context with a timeout. If the
-operation doesn't complete within the timeout, the function returns
+operation doesn't complete within the timeout, the method returns
 an error.
 
 .. code-block:: go
@@ -41,7 +41,7 @@ Expiration
 
 The driver considers a Context expired when an operation exceeds its
 timeout or is canceled. The driver checks the Context expiration with
-the ``Done()`` function.
+the ``Done()`` method.
 
 The following sections describe when and how the driver checks for
 expiration.
@@ -49,7 +49,7 @@ expiration.
 Server Selection
 ~~~~~~~~~~~~~~~~
 
-The driver might block a function call if it can't select a server for
+The driver might block a method call if it can't select a server for
 an operation.
 
 In this scenario, the driver loops until it finds a server to use for the
@@ -63,17 +63,17 @@ To learn more about how the driver selects a server, see the
 Connection Checkout
 ~~~~~~~~~~~~~~~~~~~
 
-The driver might block a function call if there are no available
+The driver might block a method call if there are no available
 connections to check out.
 
 After selecting a server, the driver tries to check out a connection
 from the server’s connection pool. If the Context expires while checking
-out a connection, the function returns a timeout error.
+out a connection, the method returns a timeout error.
 
 Connection Establishment
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The driver might block an function call if it needs to create a new
+The driver might block an method call if it needs to create a new
 connection.
 
 When the driver needs to create a new connection to execute an
@@ -104,17 +104,17 @@ socket’s read or write deadline to either the Context deadline or socket
 timeout, whichever is shorter.
 
 If you cancel the Context after the execution of the ``Read()`` or
-``Write()`` function but before its deadline, the behavior of the driver
+``Write()`` method but before its deadline, the behavior of the driver
 differs based on version.
 
 The driver generates a separate goroutine to listen for Context
-cancellation when the ``Read()`` or ``Write()`` function is in progress.
+cancellation when the ``Read()`` or ``Write()`` method is in progress.
 If the goroutine detects a cancellation, it closes the connection. The
-pending ``Read()`` or ``Write()`` function returns an error which the
+pending ``Read()`` or ``Write()`` method returns an error which the
 driver overwrites with the ``context.Canceled`` error.
 
 .. important::
 
     In versions prior to 1.5.0, the driver doesn't detect the Context
-    cancellation and waits for the ``Read()`` or ``Write()`` function to
+    cancellation and waits for the ``Read()`` or ``Write()`` method to
     return.

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -37,8 +37,7 @@ MongoDB supports the following compound operations:
 Sample Data
 ~~~~~~~~~~~
 
-Run the following snippet to load the documents into the ``ratings``
-collection of the ``tea`` database:
+Run the following snippet to load the documents into the ``tea.ratings`` collection:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/compoundOperations.go
    :language: go
@@ -53,13 +52,13 @@ collection of the ``tea`` database:
 Find and Delete
 ---------------
 
-The ``FindOneAndDelete()`` function finds the first document that matches
-the specified query filter and deletes it. The function returns a
+The ``FindOneAndDelete()`` method finds the first document that matches
+the specified query filter and deletes it. The method returns a
 ``SingleResult`` containing the deleted document.
 
 .. note:: 
 
-   This function differs from the ``DeleteOne()`` function.
+   This method differs from the ``DeleteOne()`` method.
    ``FindOneAndDelete()`` performs a find and delete as a single
    operation, and eliminates the possibility of someone altering a
    document between both operations.
@@ -67,19 +66,19 @@ the specified query filter and deletes it. The function returns a
 Modify Behavior
 ~~~~~~~~~~~~~~~
 
-You can modify the behavior of the ``FindOneAndDelete()`` function by
+You can modify the behavior of the ``FindOneAndDelete()`` method by
 passing in a ``FineOneAndDeleteOptions``. If you don't specify a
 ``FineOneAndDeleteOptions``, the driver uses the default values for each
 option.
 
 The ``FineOneAndDeleteOptions`` type allows you to configure options
-with the following functions:
+with the following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetCollation()``
@@ -106,7 +105,7 @@ Example
 ```````
 
 The following example matches and deletes a document where the ``type``
-is "Assam" with the ``FindOneAndDelete()`` function:
+is "Assam" with the ``FindOneAndDelete()`` method:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/compoundOperations.go
    :language: go
@@ -126,14 +125,14 @@ After running this example, the output resembles the following:
 Find and Update
 ---------------
 
-The ``FindOneAndUpdate()`` function finds the first document that matches
+The ``FindOneAndUpdate()`` method finds the first document that matches
 the specified query filter and updates it according to the update
-document. The function returns a ``SingleResult`` containing the matched
+document. The method returns a ``SingleResult`` containing the matched
 document.
 
 .. note:: 
 
-   This function differs from the ``UpdateOne()`` function.
+   This method differs from the ``UpdateOne()`` method.
    ``FindOneAndUpdate()`` performs a find and update as a single
    operation, and eliminates the possibility of someone altering a
    document between both operations.
@@ -141,19 +140,19 @@ document.
 Modify Behavior
 ~~~~~~~~~~~~~~~
 
-You can modify the behavior of the ``FindOneAndUpdate()`` function by
+You can modify the behavior of the ``FindOneAndUpdate()`` method by
 passing in a ``FineOneAndUpdateOptions``. If you don't specify a
 ``FineOneAndUpdateOptions``, the driver uses the default values for each
 option.
 
 The ``FineOneAndUpdateOptions`` type allows you to configure options
-with the following functions:
+with the following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetArrayFilters()``
@@ -196,7 +195,7 @@ Example
 ```````
 
 The following example performs the following actions in order with the
-``FindOneAndUpdate()`` function:
+``FindOneAndUpdate()`` method:
 
 - Matches a document where the ``type`` is "Oolong"
 - Updates the matched document's ``rating`` to ``9``
@@ -220,14 +219,14 @@ After running this example, the output resembles the following:
 Find and Replace
 ----------------
 
-The ``FindOneAndReplace()`` function finds the first document that
+The ``FindOneAndReplace()`` method finds the first document that
 matches the specified query filter and replaces it with the replacement
-document. The function returns a ``SingleResult`` containing the matched
+document. The method returns a ``SingleResult`` containing the matched
 document.
 
 .. note:: 
 
-   This function differs from the ``ReplaceOne()`` function.
+   This method differs from the ``ReplaceOne()`` method.
    ``FindOneAndReplace()`` performs a find and replace as a single
    operation, and eliminates the possibility of someone altering a
    document between both operations.
@@ -235,19 +234,19 @@ document.
 Modify Behavior
 ~~~~~~~~~~~~~~~
 
-You can modify the behavior of the ``FindOneAndReplace()`` function by
+You can modify the behavior of the ``FindOneAndReplace()`` method by
 passing in a ``FineOneAndReplaceOptions``. If you don't specify a
 ``FineOneAndReplaceOptions``, the driver uses the default values for each
 option.
 
 The ``FineOneAndReplaceOptions`` type allows you to configure options
-with the following functions:
+with the following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetBypassDocumentValidation()``
@@ -286,7 +285,7 @@ Example
 ```````
 
 The following example performs the following actions in order with the
-``FindOneAndReplace()`` function:
+``FindOneAndReplace()`` method:
 
 - Matches a document where the ``type`` is "English Breakfast"
 - Replaces the matched document with a new document where the ``type`` is "Ceylon" and  ``rating`` is ``6``
@@ -319,7 +318,7 @@ following guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `FindOneAndDelete() <{+api+}/mongo#Collection.FindOneAndDelete>`__

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -22,8 +22,7 @@ the number of documents in your collection.
 Sample Data
 ~~~~~~~~~~~
 
-To run the examples in this guide, load the sample data into the
-``ratings`` collection of the ``tea`` database with the following
+To run the examples in this guide, load the sample data into the ``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
@@ -43,11 +42,11 @@ Accurate Count
 --------------
 
 To count the number of documents that match your query filter, use the
-``CountDocuments()`` function.
+``CountDocuments()`` method.
 
 .. tip::
 
-   If you pass an empty query filter, this function returns the total
+   If you pass an empty query filter, this method returns the total
    number of documents in the collection.
 
 Modify Behavior
@@ -58,13 +57,13 @@ You can modify the behavior of ``CountDocuments()`` by passing in a
 its default values.
 
 The ``CountOptions`` type allows you to configure options with the
-following functions:
+following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetCollation()``
@@ -139,12 +138,12 @@ Estimated Count
 ---------------
 
 To estimate the number of documents in your collection, use the
-``EstimatedDocumentCount()`` function. 
+``EstimatedDocumentCount()`` method. 
 
 .. note:: 
 
-    The ``EstimatedDocumentCount()`` function is quicker than the
-    ``CountDocuments()`` function because it uses the collection's
+    The ``EstimatedDocumentCount()`` method is quicker than the
+    ``CountDocuments()`` method because it uses the collection's
     metadata rather than scanning the entire collection. 
 
 Modify Behavior
@@ -155,13 +154,13 @@ in an ``EstimatedDocumentCountOptions`` type. If you don't specify any
 options, the driver uses its default values.
 
 The ``EstimatedDocumentCountOptions`` type allows you to configure
-options with the following functions:
+options with the following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetMaxTime()``
@@ -203,7 +202,7 @@ guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `CountDocuments() <{+api+}/mongo#Collection.CountDocuments>`__

--- a/source/fundamentals/crud/read-operations/distinct.txt
+++ b/source/fundamentals/crud/read-operations/distinct.txt
@@ -22,7 +22,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load the sample data into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/distinctValues.go
@@ -41,32 +41,32 @@ Distinct
 
 To retrieve distinct values for a specified field across a single
 collection, pass the following parameters to the ``Distinct()``
-function:
+method:
 
 - The field name you want distinct values for 
 - A ``non-nil`` query filter specifying which documents to match
 
 .. tip::
 
-   If you specify an empty query filter, the function matches all the
+   If you specify an empty query filter, the method matches all the
    documents in a collection.
 
 Modify Behavior
 ~~~~~~~~~~~~~~~
 
-You can modify the behavior of the ``Distinct()`` function by
+You can modify the behavior of the ``Distinct()`` method by
 passing in a ``DistinctOptions``. If you don't specify a
 ``DistinctOptions``, the driver uses the default values for each
 option.
 
 The ``DistinctOptions`` type allows you to configure options
-with the following functions:
+with the following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetCollation()``
@@ -81,7 +81,7 @@ Example
 ```````
 
 The following example matches all documents and prints the distinct values
-of the ``type`` field using the ``Distinct()`` function: 
+of the ``type`` field using the ``Distinct()`` method: 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/distinctValues.go
    :language: go
@@ -109,7 +109,7 @@ To learn about constructing a query filter, see :ref:`golang-query-document`.
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `Distinct() <{+api+}/mongo#Collection.Distinct>`__

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -22,7 +22,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load these documents into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/limit.go
@@ -37,19 +37,19 @@ Limit
 -----
 
 To limit the number of documents returned from a query, pass the
-number of documents you want returned to the ``SetLimit()`` function of
+number of documents you want returned to the ``SetLimit()`` method of
 the read operation's options.
 
 Specify the options as the last parameter to the following read
-operation functions:
+operation methods:
 
 - ``Find()``
 - ``CountDocuments()``
 - ``gridfs.Bucket.Find()``
 
 If the limit is ``0`` or exceeds the number of matched
-documents, the function returns all the documents.  If the limit is a
-negative number, the function behaves as if the limit was the absolute
+documents, the method returns all the documents.  If the limit is a
+negative number, the method behaves as if the limit was the absolute
 value of the negative number and closes the cursor after retrieving
 documents.
 
@@ -75,7 +75,7 @@ After running this example, the output resembles the following:
 Multiple Options
 ----------------
 
-If you configure other options alongside the ``SetLimit()`` function,
+If you configure other options alongside the ``SetLimit()`` method,
 the driver performs the limit last regardless of the order you list
 the options.
 
@@ -83,7 +83,7 @@ Example
 ~~~~~~~
 
 The following example performs the following actions in order using the
-``Find()`` function:
+``Find()`` method:
 
 - Sort the ``rating`` field in descending order
 - Skip the first document
@@ -159,7 +159,7 @@ guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `FindOptions.SetLimit() <{+api+}/mongo/options#FindOptions.SetLimit>`__

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -22,7 +22,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load these documents into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/projection.go 
@@ -41,7 +41,7 @@ contains field names followed by a ``1`` (to include) or ``0`` (to
 exclude). Projections can only include or exclude fields.
 
 You can specify a projection by passing one to the ``SetProjection()``
-function in the options of the following read operation functions:
+method in the options of the following read operation methods:
 
 - ``Find()``
 - ``FindOne()``
@@ -58,14 +58,14 @@ Exclude a Field
 ~~~~~~~~~~~~~~~
 
 To exclude a field, pass the field you want to exclude and a ``0`` to
-the ``SetProjection()`` function. For all fields you don't explicitly
+the ``SetProjection()`` method. For all fields you don't explicitly
 list in the projection, the driver includes them.
 
 Example
 ```````
 
 The following example excludes the ``rating`` from the matched documents
-from the ``Find()`` function:
+from the ``Find()`` method:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/projection.go
    :language: go
@@ -89,7 +89,7 @@ Include a Field
 ~~~~~~~~~~~~~~~
 
 To include a field, pass the field you want to include and a ``1`` to
-the ``SetProjection()`` function. For all fields you don't explicitly
+the ``SetProjection()`` method. For all fields you don't explicitly
 list in the projection, the driver excludes them.
 
 .. important::
@@ -105,7 +105,7 @@ Example
 ```````
 
 The following example performs the following projection on the matched
-documents from the ``Find()`` function:
+documents from the ``Find()`` method:
 
 - Include the ``type`` and ``rating`` field
 - Exclude the ``_id`` field
@@ -137,7 +137,7 @@ Example
 ```````
 
 The following example performs the following projection on the matched
-documents from the ``Aggregate()`` function:
+documents from the ``Aggregate()`` method:
 
 - Include the ``type`` and ``rating`` field
 - Exclude the ``_id`` field
@@ -177,7 +177,7 @@ To learn about projecting text scores from your text search, see :ref:`golang-se
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `Find() <{+api+}/mongo#Collection.Find>`__

--- a/source/fundamentals/crud/read-operations/query-document.txt
+++ b/source/fundamentals/crud/read-operations/query-document.txt
@@ -47,13 +47,13 @@ Match criteria with a query operator use the following format:
 
 The following sections use :ref:`literal values <golang-literal-values>`
 and :ref:`query operators <golang-query-operators>` with the ``Find()``
-function to match a subset of documents.
+method to match a subset of documents.
 
 Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load the sample data into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/query.go
@@ -327,7 +327,7 @@ Additional Information
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types used in this
+To learn more about any of the methods or types used in this
 guide, see the following API Documentation:
 
 - `Find() <{+api+}/mongo#Collection.Find>`__

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -27,7 +27,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load these documents into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/retrieve.go
@@ -44,13 +44,13 @@ Find Operations
 ---------------
 
 Use **find operations** to retrieve data from MongoDB. Find operations
-consist of the ``Find()`` and ``FindOne()`` functions.
+consist of the ``Find()`` and ``FindOne()`` methods.
 
 Find All Documents
 ~~~~~~~~~~~~~~~~~~
 
-The ``Find()`` function expects you to pass a ``Context`` type and a
-query filter. The function returns *all* documents that match the filter
+The ``Find()`` method expects you to pass a ``Context`` type and a
+query filter. The method returns *all* documents that match the filter
 as a ``Cursor`` type.
 
 To learn how to access data in a cursor, see :ref:`golang-cursor`.
@@ -58,8 +58,8 @@ To learn how to access data in a cursor, see :ref:`golang-cursor`.
 Find One Document
 ~~~~~~~~~~~~~~~~~
 
-The ``FindOne()`` function expects you to pass a ``Context`` type and a
-query filter. The function returns *the first document* that matches the
+The ``FindOne()`` method expects you to pass a ``Context`` type and a
+query filter. The method returns *the first document* that matches the
 filter as a ``SingleResult`` type.
 
 To learn how to access data in a ``SingleResult`` see :ref:`golang-bson-unmarshalling`.
@@ -75,13 +75,13 @@ don't specify any options, the driver uses the default values for each
 option.
 
 You can configure the commonly used options in both types with the
-following functions:
+following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetCollation()`` 
@@ -95,7 +95,7 @@ following functions:
        .. note::
 
           This option is not available for ``FindOneOptions``. The
-          ``FindOne()`` function internally uses ``SetLimit(-1)``.
+          ``FindOne()`` method internally uses ``SetLimit(-1)``.
 
    * - ``SetProjection()`` 
      - | The fields to include in the returned documents. 
@@ -113,7 +113,7 @@ Example
 ```````
 
 The following example passes a context, filter, and ``FindOptions`` to
-the ``Find()`` function, which performs the following actions:
+the ``Find()`` method, which performs the following actions:
 
 - Matches documents where the ``rating`` falls between ``5`` and ``10``
 - Returns the ``type`` and ``rating``, but excludes the ``_id`` 
@@ -136,7 +136,7 @@ Example
 ```````
 
 The following example passes a context, filter, and ``FindOneOptions``
-to the ``FindOne()`` function, which performs the following actions:
+to the ``FindOne()`` method, which performs the following actions:
 
 - Matches all documents
 - A descending sort on the ``rating`` field
@@ -162,17 +162,17 @@ Aggregation Operations
 
 Use **aggregation operations** to retrieve and transform data from
 MongoDB. Perform aggregation operations using the ``Aggregate()``
-function.
+method.
 
 Aggregation
 ~~~~~~~~~~~
 
-The ``Aggregate()`` function expects you to pass a ``Context`` type and
+The ``Aggregate()`` method expects you to pass a ``Context`` type and
 an **aggregation pipeline**. An aggregation pipeline defines how to
 transform data through stages. Some of the stages are matching
 documents, renaming fields, and grouping values.
 
-The function returns the resulting documents in a ``Cursor`` type. If
+The method returns the resulting documents in a ``Cursor`` type. If
 you omit the :manual:`$match </reference/operator/aggregation/match/#mongodb-pipeline-pipe.-match>`
 stage, the pipeline proceeds using all documents in the collection.
 
@@ -181,19 +181,19 @@ To learn how to access data in a cursor, see :ref:`golang-cursor`.
 Modify Behavior
 ~~~~~~~~~~~~~~~
 
-The ``Aggregate()`` function optionally takes an ``AggregateOptions``
+The ``Aggregate()`` method optionally takes an ``AggregateOptions``
 type, which represents options you can use to modify its behavior. If
 you don't specify any options, the driver uses the default values for
 each option.
 
 The ``AggregateOptions`` type allows you to configure options with the
-following functions:
+following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetAllowDiskUse()`` 
@@ -284,7 +284,7 @@ guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `Find() <{+api+}/mongo#Collection.Find>`__

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -22,7 +22,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the example in this guide, load these documents into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/skip.go
@@ -37,11 +37,11 @@ Skip
 ----
 
 To skip a specified number of returned results from a query, pass the
-number of documents you want to skip to the ``SetSkip()`` function of
+number of documents you want to skip to the ``SetSkip()`` method of
 the read operation's options.
 
 Specify the options as the last parameter to the following read
-operation functions:
+operation methods:
 
 - ``Find()``
 - ``FindOne()``
@@ -53,18 +53,18 @@ query, that query returns no documents.
 
 .. tip::
 
-    Passing in a negative number to the ``SetSkip()`` function results
+    Passing in a negative number to the ``SetSkip()`` method results
     in a runtime error.
 
 Documents return in a natural order, which can lead to skipping random
-documents. To avoid this, use a ``SetSort()`` function before the
-``SetSkip()`` function.
+documents. To avoid this, use a ``SetSort()`` method before the
+``SetSkip()`` method.
 
 Example
 ~~~~~~~
 
 The following example performs the following actions in order with the
-``Find()`` function:
+``Find()`` method:
 
 - An ascedning sort on the ``rating`` field
 - Skips the first two documents
@@ -94,7 +94,7 @@ Example
 ~~~~~~~
 
 The following example performs the following actions in order with the
-``Aggregate()`` function:
+``Aggregate()`` method:
 
 - A descending sort on the ``rating`` field
 - Skips the first three documents
@@ -129,7 +129,7 @@ guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `Find() <{+api+}/mongo#Collection.Find>`__

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -22,7 +22,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load these documents into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/sort.go
@@ -37,11 +37,11 @@ Sort Direction
 --------------
 
 To specify the order of your results, pass an interface specifying the
-sort fields and directions to the ``SetSort()`` function of a read
+sort fields and directions to the ``SetSort()`` method of a read
 operation's options.
 
 Specify the options as the last parameter to the following read
-operation functions:
+operation methods:
 
 - ``Find()``
 - ``FindOne()``
@@ -57,11 +57,11 @@ Ascending
 
 An ascending sort orders your results from smallest to largest. To
 specify this sort, pass the field you want to sort by and ``1`` to the
-``SetSort()`` function.
+``SetSort()`` method.
 
 .. tip::
 
-   With an ascending sort, the function orders values of type
+   With an ascending sort, the method orders values of type
    ``Boolean`` from ``false`` *to* ``true``, ``String`` type values
    from *a to z* and numeric type values from *negative infinity to
    positive infinity*.
@@ -93,11 +93,11 @@ Descending
 
 A descending sort orders your results from largest to smallest. To
 specify this sort, pass the field you want to sort by and ``-1`` to the
-``SetSort()`` function.
+``SetSort()`` method.
 
 .. tip::
 
-   With an descending sort, the function orders values of type
+   With an descending sort, the method orders values of type
    ``Boolean`` from ``true`` *to* ``false``, ``String`` type values
    from *z to a* and numeric type values from *positive infinity to
    negative infinity*.
@@ -213,7 +213,7 @@ To learn about sorting text scores from your text search, see :ref:`golang-searc
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `Find() <{+api+}/mongo#Collection.Find>`__

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -27,7 +27,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load the sample data into the
-``movies`` collection of the ``marvel`` database with the following
+``marvel.movies`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/textSearch.go
@@ -91,7 +91,7 @@ To search for multiple terms, separate each term with spaces in the string.
 
 .. note::
 
-   When searching for multiple terms, the ``Find()`` function returns
+   When searching for multiple terms, the ``Find()`` method returns
    documents with at least one of the terms in text indexed fields.
 
 Example
@@ -118,7 +118,7 @@ Search by a Phrase
 
 To search for a phrase, specify the phrase with escaped quotes as a
 string in your query filter. If you don't add escaped quotes around the
-phrase, the ``Find()`` function runs a :ref:`term search <golang-term-search>`.
+phrase, the ``Find()`` method runs a :ref:`term search <golang-term-search>`.
 
 .. tip::
 
@@ -155,7 +155,7 @@ your query filter.
 
    You must search for at least one term if you want to exclude
    terms from your search. If you don't search for any terms, the
-   ``Find()`` function doesn't return any documents.
+   ``Find()`` method doesn't return any documents.
 
 Example
 ```````
@@ -212,7 +212,7 @@ After running this example, the output resembles the following:
 
 .. tip::
 
-   Although the search term was "Avenger", the function also matches
+   Although the search term was "Avenger", the method also matches
    titles containing "Avengers" because a MongoDB text index uses suffix
    stemming to match similar words. To learn more about how
    MongoDB matches terms, see :manual:`Index Entries
@@ -269,7 +269,7 @@ After running this example, the output resembles the following:
 
 .. tip::
 
-   Although the search term was "Avenger", the function also matches
+   Although the search term was "Avenger", the method also matches
    titles containing "Avengers" because a MongoDB text index uses suffix
    stemming to match similar words. To learn more about how
    MongoDB matches terms, see :manual:`Index Entries
@@ -294,7 +294,7 @@ guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `Find() <{+api+}/mongo#Collection.Find>`__

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -25,7 +25,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the example in this guide, load the sample data into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
@@ -40,24 +40,24 @@ Bulk Write
 ----------
 
 To perform a bulk operation, pass a slice of :ref:`WriteModel
-<golang-write-model>` documents to the ``BulkWrite()`` function. 
+<golang-write-model>` documents to the ``BulkWrite()`` method. 
 
 Modify Behavior
 ~~~~~~~~~~~~~~~
 
-The ``BulkWrite()`` function optionally takes a ``BulkWriteOptions``
+The ``BulkWrite()`` method optionally takes a ``BulkWriteOptions``
 type, which represents options you can use to modify its behavior. If
 you don't specify a ``BulkWriteOptions``, the driver uses the default
 values for each option.
 
 The ``BulkWriteOptions`` type allows you to configure options with the
-following functions:
+following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetBypassDocumentValidation()`` 
@@ -71,7 +71,7 @@ following functions:
 Return Values
 ~~~~~~~~~~~~~
 
-The ``BulkWrite()`` function returns a ``BulkWriteResult`` type, which
+The ``BulkWrite()`` method returns a ``BulkWriteResult`` type, which
 contains information about the bulk operation if it's successful. The
 ``BulkWriteResult`` type contains the following properties:
 
@@ -115,13 +115,13 @@ the document you want to insert. To insert multiple documents, create an
 ``InsertOneModel`` for each document you want to insert.
 
 The ``InsertOneModel`` allows you to specify its behavior with the
-following function:
+following method:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetDocument()`` 
@@ -148,13 +148,13 @@ the document you want to replace and a :ref:`replacement document
 ``ReplaceOneModel`` for each document you want to replace.
 
 The ``ReplaceOneModel`` allows you to specify its behavior with the
-following functions:
+following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetCollation()`` 
@@ -194,13 +194,13 @@ the document you want to update and an :ref:`update document
 ``UpdateManyModel``.
 
 The ``UpdateOneModel`` and ``UpdateManyModel`` allow you to specify
-their behavior with the following functions:
+their behavior with the following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetArrayFilters()`` 
@@ -241,13 +241,13 @@ the document you want to delete. To delete multiple documents, use the
 ``DeleteManyModel``. 
 
 The ``DeleteOneModel`` and ``DeleteManyModel`` allow you to specify
-their behavior with the following functions:
+their behavior with the following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetCollation()`` 
@@ -274,20 +274,20 @@ documents where the ``rating`` is greater than ``7``:
 Execution Order
 ---------------
 
-The ``BulkWrite()`` function allows you to specify if you want to
+The ``BulkWrite()`` method allows you to specify if you want to
 execute the bulk operations as ordered or unordered in its
 ``BulkWriteOptions``. 
 
 Ordered
 ~~~~~~~
 
-By default, the ``BulkWrite()`` function executes bulk operations in
+By default, the ``BulkWrite()`` method executes bulk operations in
 order you added them and stops if an error occurs.
 
 .. tip::
 
    This is equivalent to specifying ``true`` in the ``SetOrdered()``
-   function: 
+   method: 
 
    .. code-block:: go
 
@@ -297,7 +297,7 @@ Unordered
 ~~~~~~~~~
 
 To execute bulk write operations in any order and continue if an error
-occurs, specify ``false`` to the ``SetOrdered()`` function. The function
+occurs, specify ``false`` to the ``SetOrdered()`` method. The method
 reports the errors afterwards.
 
 Example
@@ -355,7 +355,7 @@ following guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `BulkWrite() <{+api+}/mongo#Collection.BulkWrite>`__

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -23,14 +23,14 @@ fields and values unchanged. Replace operations remove all existing fields
 except for ``_id`` in a document and substitute the deleted fields with
 the new fields and values you specify.
 
-In MongoDB, all functions to change documents follow the same pattern:
+In MongoDB, all methods to change documents follow the same pattern:
 
 .. figure:: /includes/figures/change_diagram.png
-   :alt: Change function signature
+   :alt: Change method signature
 
 .. note:: Placeholder
 
-   ``changeX`` is a placeholder and not a real function.
+   ``changeX`` is a placeholder and not a real method.
 
 The pattern expects you to:
 
@@ -38,7 +38,7 @@ The pattern expects you to:
 * Specify the field and value changes.
 * Specify options to modify behavior, if needed.
 
-The driver provides the following functions to change documents:
+The driver provides the following methods to change documents:
 
 * ``UpdateByID()``
 * ``UpdateOne()``
@@ -54,24 +54,24 @@ A Note About ``_id``
 Each document in a MongoDB collection has a unique and immutable ``_id``
 field. You cannot use update and replace operations to change the
 ``_id`` field. If you attempt to change this field, the update and
-replace functions return a ``WriteError``.
+replace methods return a ``WriteError``.
 
 .. _golang-update-documents:
 
 Update
 ------
 
-Use the ``UpdateOne()`` or ``UpdateByID()`` function to update a single
+Use the ``UpdateOne()`` or ``UpdateByID()`` method to update a single
 document.
 
-Use the ``UpdateMany()`` function to update multiple documents.
+Use the ``UpdateMany()`` method to update multiple documents.
 
 .. _golang-update-document:
 
 Parameters
 ~~~~~~~~~~
 
-Each function takes an **update document** that includes at least one **update operator**.
+Each method takes an **update document** that includes at least one **update operator**.
 The update operator specifies the type of update to perform. The update
 document also includes the fields and values that describe the change.
 Update documents use the following format:
@@ -122,7 +122,7 @@ contains the following properties:
      - The ``_id`` of the upserted document, or ``nil`` if there is none
 
 If multiple documents match the query filter passed to ``UpdateOne()``,
-the function selects and updates the first matched document. If no
+the method selects and updates the first matched document. If no
 documents match the query filter, the update operation makes no
 changes. 
 
@@ -146,7 +146,7 @@ The following document describes an employee:
       ...
    }
 
-The following example uses the ``UpdateByID()`` function to:
+The following example uses the ``UpdateByID()`` method to:
 
 - Match the document where the ``_id`` value is 2158.
 - Set the ``name`` field to "Mary Wollstonecraft Shelley" and the
@@ -190,7 +190,7 @@ The following shows the updated document resulting from the preceding update ope
 Replace
 -------
 
-Use the ``ReplaceOne()`` function to replace a single document.
+Use the ``ReplaceOne()`` method to replace a single document.
 
 Parameters
 ~~~~~~~~~~
@@ -230,7 +230,7 @@ successful. The ``UpdateResult`` type contains the following properties:
      - The ``_id`` of the upserted document, or ``nil`` if there is none
 
 If multiple documents match the query filter passed to ``ReplaceOne()``,
-the function selects and replaces the first matched document. Your replace
+the method selects and replaces the first matched document. Your replace
 operation fails if no documents match the query filter.
 
 Example
@@ -249,7 +249,7 @@ The following document describes a kitchen item:
       "material" : "Glass"
    }
 
-The following example uses the ``ReplaceOne()`` function to substitute
+The following example uses the ``ReplaceOne()`` method to substitute
 this document with one that contains an ``item`` field with a
 value of "Cup" and a ``quantity`` field with a value of 107:
 
@@ -305,7 +305,7 @@ To learn more about updating array elements, see :ref:`golang-update-arrays`.
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `WriteError <{+api+}/mongo#WriteError>`__

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -22,7 +22,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the example in this guide, load these documents into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/delete.go
@@ -40,7 +40,7 @@ Delete Operations
 -----------------
 
 Use **delete operations** to remove data from MongoDB. Delete operations
-consist of the following functions:
+consist of the following methods:
 
 - ``DeleteOne()``, which deletes *the first document* that matches the filter
 - ``DeleteMany()``, which deletes *all* documents that match the filter
@@ -48,12 +48,12 @@ consist of the following functions:
 .. tip::
 
    If one document matches your filter when running the ``DeleteMany()``
-   function, it's equivalent to running the ``DeleteOne()`` function.
+   method, it's equivalent to running the ``DeleteOne()`` method.
 
 Parameters
 ~~~~~~~~~~
 
-The ``DeleteOne()`` and ``DeleteMany()`` functions expect you to pass a
+The ``DeleteOne()`` and ``DeleteMany()`` methods expect you to pass a
 ``Context`` type and a ``non-nil`` query filter specifying which
 documents to match.
 
@@ -63,13 +63,13 @@ If you don't specify a ``DeleteOptions``, the driver uses the default
 values for each option.
 
 The ``DeleteOptions`` type allows you to configure options with the
-following functions:
+following methods:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Method
      - Description
 
    * - ``SetHint()``
@@ -83,7 +83,7 @@ following functions:
 Return Value
 ~~~~~~~~~~~~
 
-The ``DeleteOne()`` and ``DeleteMany()`` functions return a
+The ``DeleteOne()`` and ``DeleteMany()`` methods return a
 ``DeleteResult`` type. This type contains the ``DeletedCount`` property,
 which states the number of documents deleted. If there are no matches to
 your filter, no document gets deleted and ``DeletedCount`` is ``0``.
@@ -92,10 +92,10 @@ Example
 ```````
 
 The following example performs the following with the ``DeleteMany()``
-function:
+method:
 
 - Matches and deletes documents where the ``rating`` is greater than ``8``
-- Specifies the function to use the ``_id`` as the index
+- Specifies the method to use the ``_id`` as the index
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/delete.go
    :language: go
@@ -112,7 +112,7 @@ After running the preceding example, the output resembles the following:
 
 .. tip::
 
-   If the preceding example used the ``DeleteOne()`` function instead of
+   If the preceding example used the ``DeleteOne()`` method instead of
    ``DeleteMany()``, the driver would delete the first of the two
    matched documents.
 
@@ -138,7 +138,7 @@ To learn about how the driver uses Context, see :ref:`golang-context`.
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `DeleteOne() <{+api+}/mongo#Collection.DeleteOne>`__

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -27,7 +27,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the examples in this guide, load the sample data into the
-``tea`` collection of the ``quantity`` database with the following
+``quantity.tea`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
@@ -38,10 +38,10 @@ snippet:
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
-The following examples use the ``FindOneAndUpdate()`` function to
+The following examples use the ``FindOneAndUpdate()`` method to
 retrieve and update a document and to return the state of the document
 after the update occurs. If you want to update multiple documents with
-an array field, use the ``UpdateMany()`` function.
+an array field, use the ``UpdateMany()`` method.
 
 .. include:: /includes/fundamentals/truncated-id.rst
 
@@ -113,7 +113,7 @@ Example
 This example performs the following actions:
 
 - Creates an array filter with an identifier called ``smaller`` to match elements less than ``18``.
-- Applies the array filter using the ``SetArrayFilters()`` function.
+- Applies the array filter using the ``SetArrayFilters()`` method.
 - Increments every matched element by ``7``.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
@@ -177,7 +177,7 @@ following guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `FindOneAndUpdate() <{+api+}/mongo#Collection.FindOneAndUpdate>`__

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -21,13 +21,13 @@ collection.
 
 Before you can find, update, and delete documents in MongoDB, you need
 to insert those documents. You can insert one document using
-the ``InsertOne()`` function, or insert multiple documents using either
-the ``InsertMany()`` or ``BulkWrite()`` functions.
+the ``InsertOne()`` method, or insert multiple documents using either
+the ``InsertMany()`` or ``BulkWrite()`` method.
 
 The following sections focus on ``InsertOne()`` and ``InsertMany()``.
 
 ..
-  For an example on how to use the ``BulkWrite()`` function, see :ref:`golang-bulk-ops-usage-example`.
+  For an example on how to use the ``BulkWrite()`` method, see :ref:`golang-bulk-ops-usage-example`.
 
 The ``_id`` Field
 -----------------
@@ -58,9 +58,9 @@ Server Manual Entry on :manual:`Documents </core/document>`.
 Insert a Document
 -----------------
 
-Use the ``InsertOne()`` function to insert a single document into a collection.
+Use the ``InsertOne()`` method to insert a single document into a collection.
 
-Upon successful insertion, the function returns an
+Upon successful insertion, the method returns an
 ``InsertOneResult`` instance that contains the ``_id`` of
 the new document.
 
@@ -69,7 +69,7 @@ Example
 
 The following example creates and inserts a document into the
 ``favorite_books`` collection using the
-``InsertOne()`` function:
+``InsertOne()`` method:
 
 .. code-block:: go
 
@@ -118,17 +118,17 @@ Construct an ``InsertOneOptions`` as follows:
 Insert Multiple Documents
 -------------------------
 
-Use the ``InsertMany()`` function to insert multiple documents into a
+Use the ``InsertMany()`` method to insert multiple documents into a
 collection.
 
-Upon successful insertion, the ``InsertMany()`` function returns an ``InsertManyResult``
+Upon successful insertion, the ``InsertMany()`` method returns an ``InsertManyResult``
 instance that contains the ``_id`` fields of the inserted documents.
 
 Example
 ~~~~~~~
 
 The following example creates and inserts some documents into the
-``favorite_books`` collection using the ``InsertMany()`` function:
+``favorite_books`` collection using the ``InsertMany()`` method:
 
 .. code-block:: go
 
@@ -274,7 +274,7 @@ following guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `WriteError <{+api+}/mongo#WriteError>`__

--- a/source/fundamentals/crud/write-operations/upsert.txt
+++ b/source/fundamentals/crud/write-operations/upsert.txt
@@ -22,7 +22,7 @@ Sample Data
 ~~~~~~~~~~~
 
 To run the example in this guide, load the sample data into the
-``ratings`` collection of the ``tea`` database with the following
+``tea.ratings`` collection with the following
 snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/upsert.go
@@ -52,7 +52,7 @@ An upsert performs one of the following actions:
 - Insert a document if there are no matches to your query filter
 
 You can specify an upsert by passing ``true`` to the ``SetUpsert()``
-function in the options of the following write operation functions:
+method in the options of the following write operation methods:
 
 - ``UpdateOne()``
 - ``UpdateByID()``
@@ -65,7 +65,7 @@ function in the options of the following write operation functions:
 
    If you don't specify an upsert, no change occurs in the write
    operation when zero documents match your query filter. This is
-   equivalent to passing ``false`` to the ``SetUpsert()`` function.
+   equivalent to passing ``false`` to the ``SetUpsert()`` method.
 
 Example
 ~~~~~~~
@@ -103,7 +103,7 @@ guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types mentioned in this
+To learn more about any of the methods or types mentioned in this
 guide, see the following API Documentation:
 
 - `UpdateOne() <{+api+}/mongo#Collection.UpdateOne>`__

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -195,8 +195,8 @@ the geospatial data for inclusion, intersection, and proximity. To learn more ab
 To create a 2dsphere index, you must specify a field that contains only **GeoJSON objects**. To learn more about this
 type, see the MongoDB server manual page on :manual:`GeoJSON objects </reference/geojson>`.
 
-The ``location.geo` field in following sample document from the ``theaters`` collection in the ``sample_mflix```
-database is a GeoJSON Point object that describes the coordinates of the theater:
+The ``location.geo` field in following sample document from the ``sample_mflix.theaters``
+collection is a GeoJSON Point object that describes the coordinates of the theater:
 
 .. code-block:: javascript
 

--- a/source/fundamentals/time-series.txt
+++ b/source/fundamentals/time-series.txt
@@ -51,7 +51,7 @@ Create a Time Series Collection
    Time series collections require MongoDB 5.0 or later.
 
 To create a time series collection, pass the following parameters to the
-``CreateCollection()`` function:
+``CreateCollection()`` method:
 
 - The name of the new collection to create
 - The ``TimeSeriesOptions`` object specifying at least the time field
@@ -70,7 +70,7 @@ collection with the ``temperature`` as the time field:
    :dedent:
 
 To check if you created the collection, send the ``"listCollections"``
-command to the ``RunCommand()`` function:
+command to the ``RunCommand()`` method:
 
 .. io-code-block::
    :caption: Testing whether we created a time series collection.
@@ -126,7 +126,7 @@ guides:
 API Documentation
 ~~~~~~~~~~~~~~~~~
 
-To learn more about any of the functions or types discussed in this
+To learn more about any of the methods or types discussed in this
 guide, see the following API Documentation:
 
 - `TimeSeriesOptions <{+api+}/mongo/options#TimeSeriesOptions>`__

--- a/source/index.txt
+++ b/source/index.txt
@@ -52,7 +52,7 @@ Fundamentals
 API
 ---
 
-For detailed information about types and functions in the MongoDB
+For detailed information about types and methods in the MongoDB
 Go driver, see the `{+driver-long+} API documentation
 <{+api+}/mongo>`__.
 


### PR DESCRIPTION
# Pull Request Info

Switched all instances of "function" to "method" to align with Go API docs. 
Updated references to collections to use dot notation

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-21849>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-21849/fundamentals/crud/read-operations/query-document/>

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Did you run a spell-check?
- [X] Did you run a grammar-check?
- [X] Are all the links working?
