### PR TITLE
DOCSP-22511 Usage Example Tip

### DIFF
--- a/source/includes/usage-examples/bulk-write-example-tip.rst
+++ b/source/includes/usage-examples/bulk-write-example-tip.rst
@@ -1,0 +1,5 @@
+.. tip::
+
+   Read the :ref:`golang-usage-examples` to learn how to set up your environment to run this example.
+
+   This example modifies sample documents inserted in a previous example. To add the documents, see :ref:`golang-insert-many`.

--- a/source/includes/usage-examples/replace-example-note.rst
+++ b/source/includes/usage-examples/replace-example-note.rst
@@ -1,0 +1,5 @@
+.. note::
+
+   Read the :ref:`golang-usage-examples` to learn how to set up your environment to run this example.
+
+   This example replaces a sample document inserted in a previous example. To add this sample document, see :ref:`golang-insert`.

--- a/source/includes/usage-examples/replace-example-note.rst
+++ b/source/includes/usage-examples/replace-example-note.rst
@@ -2,4 +2,4 @@
 
    Read the :ref:`golang-usage-examples` to learn how to set up your environment to run this example.
 
-   This example replaces a sample document inserted in a previous example. To add this sample document, see :ref:`golang-insert`.
+   This example replaces a sample document inserted in a previous example. To add the document, see :ref:`golang-insert-one`.

--- a/source/includes/usage-examples/replace-example-tip.rst
+++ b/source/includes/usage-examples/replace-example-tip.rst
@@ -1,4 +1,4 @@
-.. note::
+.. tip::
 
    Read the :ref:`golang-usage-examples` to learn how to set up your environment to run this example.
 

--- a/source/includes/usage-examples/run-example-tip.rst
+++ b/source/includes/usage-examples/run-example-tip.rst
@@ -1,3 +1,3 @@
 .. tip::
 
-   Read the :ref:`golang-usage-examples` to learn how to run this example.
+   Read the :ref:`golang-usage-examples` to learn how to set up your environment to run this example.

--- a/source/includes/usage-examples/run-example-tip.rst
+++ b/source/includes/usage-examples/run-example-tip.rst
@@ -1,4 +1,3 @@
 .. tip::
 
-   Read the :ref:`golang-usage-examples` to learn how
-   to run this example.
+   You must follow the :ref:`golang-usage-examples` instructions before running this example.

--- a/source/includes/usage-examples/run-example-tip.rst
+++ b/source/includes/usage-examples/run-example-tip.rst
@@ -1,3 +1,3 @@
 .. tip::
 
-   You must follow the :ref:`golang-usage-examples` instructions before running this example.
+   Read the :ref:`golang-usage-examples` to learn how to run this example.

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -12,14 +12,14 @@ You can perform bulk write operations on a collection by using the
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example performs the following in order on the ``haikus``
 collection:
 
 - Matches a document in which the ``title`` is "Record of a Shriveled Datum" and replace it with a new document
 - Matches a document in which the ``title`` is "Dodging Greys" and updates that value to "Dodge The Greys"
 
+.. include:: /includes/usage-examples/bulk-write-example-tip.rst
+   
 .. literalinclude:: /includes/usage-examples/code-snippets/bulk.go
    :start-after: begin bulk
    :end-before: end bulk

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -12,10 +12,10 @@ You can run commands directly on your MongoDB server by using the
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example retrieves statistics about the
 ``sample_restaurants`` database:
+
+.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/command.go
    :start-after: begin runCommand

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -14,14 +14,14 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example performs the following on the ``movies``
 collection:
 
 - Approximates the number of documents in the collection
 - Counts the number of documents in which the ``countries`` contains "China"
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+    
 .. literalinclude:: /includes/usage-examples/code-snippets/count.go
    :start-after: begin countDocuments
    :end-before: end countDocuments

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -12,12 +12,12 @@ You can delete multiple documents in a collection by using the
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example matches documents in the ``movies`` collection
 in which the ``runtime`` is greater than 800 minutes, deleting all
 documents matched:
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+   
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteMany.go
    :start-after: begin deleteMany
    :end-before: end deleteMany

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -12,12 +12,12 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example matches documents in the ``movies`` collection
 in which the ``title`` is "Twilight", deleting the first document
 matched:
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+   
 .. literalinclude:: /includes/usage-examples/code-snippets/deleteOne.go
    :start-after: begin deleteOne
    :end-before: end deleteOne

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -12,14 +12,14 @@ collection by using the ``Distinct()`` method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example performs the following on the ``movies``
 collection:
 
 - Matches documents in which the ``directors`` contains "Natalie Portman"
 - Returns distinct values of the ``title`` from the matched documents
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+   
 .. literalinclude:: /includes/usage-examples/code-snippets/distinct.go
    :start-after: begin distinct
    :end-before: end distinct

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -12,11 +12,11 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example matches documents in the ``zips`` collection
 in which the ``pop`` is less than or equal to 500 people,
 returning all documents matched:
+
+.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/find.go
    :start-after: begin find

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -17,6 +17,8 @@ The following example matches documents in the ``movies`` collection
 in which the ``title`` is "The Room", returning the first document
 matched:
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
    :start-after: begin findOne
    :end-before: end findOne
@@ -25,8 +27,6 @@ matched:
    :emphasize-lines: 4
 
 View a `fully runnable example <{+example+}/findOne.go>`__
-
-.. include:: /includes/usage-examples/run-example-tip.rst
 
 Expected Result
 ---------------

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -13,8 +13,6 @@ You can retrieve a single document from a collection by using the
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example matches documents in the ``movies`` collection
 in which the ``title`` is "The Room", returning the first document
 matched:
@@ -27,6 +25,8 @@ matched:
    :emphasize-lines: 4
 
 View a `fully runnable example <{+example+}/findOne.go>`__
+
+.. include:: /includes/usage-examples/run-example-tip.rst
 
 Expected Result
 ---------------

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -12,12 +12,12 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example inserts two documents in the ``haikus`` collection:
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+  
 .. literalinclude:: /includes/usage-examples/code-snippets/insertMany.go
    :start-after: begin insertMany
    :end-before: end insertMany

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -12,11 +12,11 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example inserts a document in the ``haikus`` collection:
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
+
+.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/insertOne.go
    :start-after: begin insertOne

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -12,13 +12,14 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example performs the following on the ``haikus``
 collection:
 
 - Matches a document in which the ``title`` is "Record of a Shriveled Datum"
 - Replaces the matched document with a new document
+
+
+.. include:: /includes/usage-examples/replace-example-note.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/replace.go
    :start-after: begin replace

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -19,7 +19,7 @@ collection:
 - Replaces the matched document with a new document
 
 
-.. include:: /includes/usage-examples/replace-example-note.rst
+.. include:: /includes/usage-examples/replace-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/replace.go
    :start-after: begin replace

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -10,8 +10,6 @@ structs to :manual:`BSON </reference/bson-types/>` by using struct tags.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following code declares a struct of type ``BlogPost``. This struct
 contains a struct tag that maps the ``WordCount`` field to the BSON
 field name ``word_count``. By default, the driver marshals the other

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -12,13 +12,13 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example performs the following on the
 ``listingsAndReviews`` collection:
 
 - Matches documents in which the market field of the address subdocument, ``address.market`` is "Sydney"
 - Updates the ``price`` in the matched documents by 1.15 times
+
+.. include:: /includes/usage-examples/run-example-tip.rst
 
 .. literalinclude:: /includes/usage-examples/code-snippets/updateMany.go
    :start-after: begin updatemany

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -12,14 +12,14 @@ method.
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example performs the following on the ``restaurants``
 collection:
 
 - Matches a document with a specific ``_id``
 - Creates a new field in the matched document called ``avg_rating`` with a value of 4.4
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+   
 .. literalinclude:: /includes/usage-examples/code-snippets/updateOne.go
    :start-after: begin updateone
    :end-before: end updateone

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -12,11 +12,11 @@ You can open a change stream on a ``MongoCollection``,
 Example
 -------
 
-.. include:: /includes/usage-examples/run-example-tip.rst
-
 The following example opens a change stream on the ``haikus`` collection
 and prints inserted documents:
 
+.. include:: /includes/usage-examples/run-example-tip.rst
+   
 .. literalinclude:: /includes/usage-examples/code-snippets/watch.go
    :start-after: begin watch
    :end-before: end watch


### PR DESCRIPTION
# Pull Request Info

Updated the text in the Usage Example tip and moved it closer to the code example it applies to
Added text specifying when previous tutorial steps need to be followed before running code examples

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-22511>

Staging - 
Updated tip: <https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-22511/usage-examples/findOne/>
Added text: <https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-22511/usage-examples/replaceOne/>
<https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-22511/usage-examples/bulkWrite/>
Changes apply to all pages under "Usage Examples" in TOC

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Did you run a spell-check?
- [X] Did you run a grammar-check?
- [X] Are all the links working?
