### PR TITLE
DOCSP-19058 stable api

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -19,3 +19,4 @@ docs-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1
 version = "v1.10.0-beta1" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
 example = "https://raw.githubusercontent.com/mongodb/docs-golang/{+docs-branch+}/source/includes/usage-examples/code-snippets"
 api = "https://pkg.go.dev/go.mongodb.org/mongo-driver@{+version+}"
+stable-api = "Stable API"

--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -9,6 +9,7 @@ Fundamentals
    :maxdepth: 1
 
    /fundamentals/connection
+   /fundamentals/stable-api
    /fundamentals/context
    /fundamentals/auth
    /fundamentals/bson

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -52,7 +52,7 @@ your connection.
 
 .. note:: 
    
-   The {+driver-long+} only supports ``ServerAPIVersion1``.
+   The {+driver-long+} currently only supports ``ServerAPIVersion1``.
 
 Example
 ~~~~~~~
@@ -80,9 +80,9 @@ The following example instantiates a ``Client`` that sets the
 Modify Behavior
 ---------------
 
-You can modify the behavior of the ``ServerAPI()`` method by appending
-to the ``ServerAPIOptions`` type. If you don't specify any options, the
-driver uses the default values for each option.
+You can further modify the behavior of the stable API feature by
+appending to the ``ServerAPIOptions`` type. If you don't specify any
+options, the driver uses the default values for each option.
 
 .. list-table::
    :header-rows: 1
@@ -98,12 +98,12 @@ driver uses the default values for each option.
        | Default: **ServerAPIVersion1**
 
    * - ``SetStrict()``
-     - | Flag that indicates whether  the server should return errors for features that aren't part of the API version.
+     - | Flag that indicates whether the server should return errors for features that aren't part of the API version.
        |
        | Default: **false**
 
    * - ``SetDeprecationErrors()``
-     - | Flag that indicates whether  the server should return errors for deprecated features.
+     - | Flag that indicates whether the server should return errors for deprecated features.
        |
        | Default: **false**
 
@@ -146,7 +146,7 @@ API Documentation:
 - `Client <{+api+}/mongo/options#Client>`__
 - `ClientOptions <{+api+}/mongo/options#ClientOptions>`__
 - `ServerAPI() <{+api+}/mongo/options#ServerAPI>`__
-- `ServerAPIOptions() <{+api+}/mongo/options#ServerAPIOptions>`__
+- `ServerAPIOptions <{+api+}/mongo/options#ServerAPIOptions>`__
 - `ServerApiVersion <{+api+}/mongo/options#ServerAPIVersion>`__
 - `SetDeprecationErrors() <{+api+}/mongo/options#ServerAPIOptions.SetDeprecationErrors>`__
 - `SetStrict() <{+api+}/mongo/options#ServerAPIOptions.SetStrict>`__

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -1,0 +1,144 @@
+.. _golang-stable-api:
+
+==============
+{+stable-api+}
+==============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to specify the {+stable-api+} when
+connecting to a MongoDB instance or replica set. 
+
+.. note::
+
+   The {+stable-api+} feature requires MongoDB Server 5.0 or later.
+
+   You should only use the {+stable-api+} feature if all the MongoDB
+   servers you are connecting to support this feature.
+
+{+stable-api+}
+--------------
+
+The {+stable-api+} feature forces the server to run operations with
+behaviors compatible with the **API version** you specify. An API
+version defines the expected behavior of the operations it covers and
+the format of server responses. The operations and the server responses
+may differ depending on the API version you specify.
+
+With an official MongoDB driver, you can update your driver or server
+without worrying about backward compatibility issues of the commands
+covered by the {+stable-api+}.
+
+To learn more about the list of commands the server covers, see
+:manual:`{+stable-api+} </reference/stable-api/>`. 
+
+Specify an API Version
+----------------------
+
+The ``Client`` optionally takes a ``ServerAPIOptions`` type through
+the ``ClientOptions``.  
+
+To specify an API version, append the ``SetServerAPIOptions()`` method
+with your :ref:`ServerAPIOptions <golang-stable-api-options>` to your
+``ClientOptions``.
+
+.. note:: 
+   
+   The {+driver-long+} currently supports ``ServerAPIVersion1``.
+
+Example
+~~~~~~~
+
+The following example instantiates a ``Client`` that sets the
+{+stable-api+} version and connects to a server.
+
+.. code-block:: go
+   :copyable: true
+
+   // Specify a server URI to connect to
+   uri:= "mongodb://<hostname>:<port>"
+
+   // Specify the Stable API version in the ClientOptions object
+   serverAPI := options.ServerAPI(options.ServerAPIVersion1)
+   
+   // Pass in the URI and the ClientOptions to the Client
+   client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPI))
+   if err != nil {
+       panic(err)
+   }
+
+.. _golang-stable-api-options:
+
+Modify Behavior
+---------------
+
+You can modify the behavior of the ``ServerAPI()`` method by appending
+to the ``ServerAPIOptions`` type. If you don't specify any options, the
+driver uses the default values for each option.
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 30 70
+
+   * - Method
+     - Description
+
+   * - ``ServerAPI()``
+     - | The API version to use.
+       |
+       | Default: **ServerAPIVersion1**
+
+   * - ``SetStrict()``
+     - | Whether the server should return errors for features that are not part of the API version.
+       |
+       | Default: **false**
+
+   * - ``SetDeprecationErrors()``
+     - | Whether the server should return errors for deprecated features.
+       |
+       | Default: **false**
+
+Example
+~~~~~~~
+
+The following example sets the all of the available options of the
+``ServerAPI`` to ``true``.
+
+.. code-block:: go
+   :copyable: true
+    
+   // Specify a server URI to connect to
+   uri:= "mongodb://<hostname>:<port>"
+
+   // Specify the Stable API version and append options in the ClientOptions object
+   serverAPI := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true).SetDeprecationErrors(true)
+   
+   // Pass in the URI and the ClientOptions to the Client
+   client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPI))
+   if err != nil {
+       panic(err)
+   }
+
+Additional Information
+----------------------
+
+For more information on the options in this section, see the following
+API Documentation:
+
+- `Client <{+api+}/mongo/options#Client>`__
+- `ClientOptions <{+api+}/mongo/options#ClientOptions>`__
+- `ServerAPI() <{+api+}/mongo/options#ServerAPI>`__
+- `ServerAPIOptions() <mongo/options#ServerAPIOptions>`__
+- `ServerApiVersion <{+api+}/mongo/options#ServerAPIVersion>`__
+- `SetDeprecationErrors() <{+api+}/mongo/options#ServerAPIOptions.SetDeprecationErrors>`__
+- `SetStrict() <{+api+}/mongo/options#ServerAPIOptions.SetStrict>`__

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -12,12 +12,6 @@
    :depth: 1
    :class: singlecol
 
-Overview
---------
-
-In this guide, you can learn how to specify the {+stable-api+} when
-connecting to a MongoDB instance or replica set. 
-
 .. note::
 
    The {+stable-api+} feature requires MongoDB Server 5.0 or later.
@@ -25,8 +19,11 @@ connecting to a MongoDB instance or replica set.
    You should only use the {+stable-api+} feature if all the MongoDB
    servers you are connecting to support this feature.
 
-{+stable-api+}
---------------
+Overview
+--------
+
+In this guide, you can learn how to specify the **{+stable-api+}** when
+connecting to a MongoDB instance or replica set. 
 
 The {+stable-api+} feature forces the server to run operations with
 behaviors compatible with the **API version** you specify. An API
@@ -38,7 +35,7 @@ With an official MongoDB driver, you can update your driver or server
 without worrying about backward compatibility issues of the commands
 covered by the {+stable-api+}.
 
-To learn more about the list of commands the server covers, see
+To learn more about the commands the server covers, see
 :manual:`{+stable-api+} </reference/stable-api/>`. 
 
 Specify an API Version
@@ -48,12 +45,12 @@ The ``Client`` optionally takes a ``ServerAPIOptions`` type through
 the ``ClientOptions``.  
 
 To specify an API version, append the ``SetServerAPIOptions()`` method
-with your :ref:`ServerAPIOptions <golang-stable-api-options>` to your
+with your :ref:`server API options <golang-stable-api-options>` to your
 ``ClientOptions``.
 
 .. note:: 
    
-   The {+driver-long+} currently supports ``ServerAPIVersion1``.
+   The {+driver-long+} only supports ``ServerAPIVersion1``.
 
 Example
 ~~~~~~~
@@ -99,7 +96,7 @@ driver uses the default values for each option.
        | Default: **ServerAPIVersion1**
 
    * - ``SetStrict()``
-     - | Whether the server should return errors for features that are not part of the API version.
+     - | Whether the server should return errors for features that aren't part of the API version.
        |
        | Default: **false**
 
@@ -111,8 +108,11 @@ driver uses the default values for each option.
 Example
 ~~~~~~~
 
-The following example sets the all of the available options of the
-``ServerAPI`` to ``true``.
+This example specifies for the server to perfrom the following actions:
+
+- Use Version 1 of the API
+- Return errors for features that aren't part of Version 1
+- Return errors for deprecated features
 
 .. code-block:: go
    :copyable: true
@@ -131,6 +131,12 @@ The following example sets the all of the available options of the
 
 Additional Information
 ----------------------
+
+To learn more about connecting to your MongoDB instance or replica set,
+see :ref:`golang-connection-guide`.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
 
 For more information on the options in this section, see the following
 API Documentation:

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -144,7 +144,7 @@ API Documentation:
 - `Client <{+api+}/mongo/options#Client>`__
 - `ClientOptions <{+api+}/mongo/options#ClientOptions>`__
 - `ServerAPI() <{+api+}/mongo/options#ServerAPI>`__
-- `ServerAPIOptions() <mongo/options#ServerAPIOptions>`__
+- `ServerAPIOptions() <{+api+}/mongo/options#ServerAPIOptions>`__
 - `ServerApiVersion <{+api+}/mongo/options#ServerAPIVersion>`__
 - `SetDeprecationErrors() <{+api+}/mongo/options#ServerAPIOptions.SetDeprecationErrors>`__
 - `SetStrict() <{+api+}/mongo/options#ServerAPIOptions.SetStrict>`__

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -64,7 +64,7 @@ The following example instantiates a ``Client`` that sets the
    :copyable: true
 
    // Specify a server URI to connect to
-   uri:= "mongodb://<hostname>:<port>"
+   uri := "mongodb://<hostname>:<port>"
 
    // Specify the Stable API version in the ClientOptions object
    serverAPI := options.ServerAPI(options.ServerAPIVersion1)
@@ -120,7 +120,7 @@ This example specifies for the server to perform the following actions:
    :copyable: true
     
    // Specify a server URI to connect to
-   uri:= "mongodb://<hostname>:<port>"
+   uri := "mongodb://<hostname>:<port>"
 
    // Specify the Stable API version and append options in the ClientOptions object
    serverAPI := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true).SetDeprecationErrors(true)

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -22,8 +22,8 @@
 Overview
 --------
 
-In this guide, you can learn how to specify the **{+stable-api+}** when
-connecting to a MongoDB instance or replica set. 
+In this guide, you can learn how to specify **{+stable-api+}**
+compatibility when connecting to a MongoDB instance or replica set.
 
 The {+stable-api+} feature forces the server to run operations with
 behaviors compatible with the **API version** you specify. An API
@@ -31,9 +31,9 @@ version defines the expected behavior of the operations it covers and
 the format of server responses. The operations and the server responses
 may differ depending on the API version you specify.
 
-With an official MongoDB driver, you can update your driver or server
-without worrying about backward compatibility issues of the commands
-covered by the {+stable-api+}.
+When you use the Stable API feature with an official MongoDB driver, you
+can update your driver or server without worrying about backward
+compatibility issues of the commands covered by the {+stable-api+}.
 
 To learn more about the commands the server covers, see
 :manual:`{+stable-api+} </reference/stable-api/>`. 
@@ -46,7 +46,9 @@ the ``ClientOptions``.
 
 To specify an API version, append the ``SetServerAPIOptions()`` method
 with your :ref:`server API options <golang-stable-api-options>` to your
-``ClientOptions``.
+``ClientOptions``. After you specify an API version, the ``Client`` runs
+operations that are compatible with the API version for the duration of
+your connection.
 
 .. note:: 
    
@@ -96,19 +98,19 @@ driver uses the default values for each option.
        | Default: **ServerAPIVersion1**
 
    * - ``SetStrict()``
-     - | Whether the server should return errors for features that aren't part of the API version.
+     - | Flag that indicates whether  the server should return errors for features that aren't part of the API version.
        |
        | Default: **false**
 
    * - ``SetDeprecationErrors()``
-     - | Whether the server should return errors for deprecated features.
+     - | Flag that indicates whether  the server should return errors for deprecated features.
        |
        | Default: **false**
 
 Example
 ~~~~~~~
 
-This example specifies for the server to perfrom the following actions:
+This example specifies for the server to perform the following actions:
 
 - Use Version 1 of the API
 - Return errors for features that aren't part of Version 1

--- a/source/includes/fundamentals-sections.rst
+++ b/source/includes/fundamentals-sections.rst
@@ -2,6 +2,7 @@ Learn how to perform the following tasks using the Go driver in the
 Fundamentals section:
 
 - :ref:`Connect to MongoDB <golang-connection-guide>`
+- :ref:`Specify an API Version <golang-stable-api>`
 - :ref:`How the Driver Uses Context <golang-context>`
 - :ref:`Authenticate with MongoDB <golang-authentication-mechanisms>`
 - :ref:`Read from and Write to MongoDB <golang-crud>`
@@ -9,7 +10,6 @@ Fundamentals section:
 - :ref:`Perform Aggregations <golang-aggregation>`
 - :ref:`Use a Time Series Collection <golang-time-series>`
 
-.. - :doc:`Specify an API Version </fundamentals/versioned-api>`
 .. - :doc:`Use the Driver's Data Formats </fundamentals/data-formats>`
 .. - :doc:`Construct Indexes </fundamentals/indexes>`
 .. - :doc:`Specify Collations </fundamentals/collations>`


### PR DESCRIPTION
# Pull Request Info

Added the Stable API page -- based off the existing [Java](https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/stable-api/) and [Node.js](https://www.mongodb.com/docs/drivers/node/current/fundamentals/stable-api/) one.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-19058>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-19058/fundamentals/stable-api/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
