### PR TITLE
add go 1.10

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,6 @@
 define: prefix docs/drivers/go
 define: base https://www.mongodb.com/${prefix}
-define: versions master
+define: versions 1.7 1.8 1.9 1.10 master
 
 raw: ${prefix}/ -> ${base}/current/
 raw: ${prefix}/stable -> ${base}/current/

--- a/snooty.toml
+++ b/snooty.toml
@@ -16,7 +16,7 @@ sharedinclude_root = "https://raw.githubusercontent.com/10gen/docs-shared/main/"
 [constants]
 driver-long = "MongoDB Go Driver"
 docs-branch = "master" # always set this to the docs branch (i.e. master, 1.7, 1.8, etc.)
-version = "v1.10.0-beta1" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
+version = "v1.10.1" # always set this to the driver branch (i.e. v1.7.0, v1.8.0, etc.)
 example = "https://raw.githubusercontent.com/mongodb/docs-golang/{+docs-branch+}/source/includes/usage-examples/code-snippets"
 api = "https://pkg.go.dev/go.mongodb.org/mongo-driver@{+version+}"
 stable-api = "Stable API"


### PR DESCRIPTION
# Pull Request Info

It looks like we missed publishing the 1.10 branch for Go. This adds the latest to master, and fills out the redirects file to be the same format as our other drivers.

This will be cherry-picked to the new 1.10 branch and the `version` in snooty will be updated.

Paired with @jordan-smith721 

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - N/A
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/publish-go-1.10/) 

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
