### PR TITLE
DOCSP-25874 Add Restaurant Structs to FindOne Usage Example

### DIFF
--- a/source/includes/usage-examples/code-snippets/findOne.go
+++ b/source/includes/usage-examples/code-snippets/findOne.go
@@ -36,24 +36,25 @@ func main() {
 
 	type Address struct {
 		Building    string
-		Coordinates [2]float64
+		Coordinates [2]float64 `bson:"coord"`
 		Street      string
 		Zipcode     string
 	}
 
 	type Grades struct {
 		Date  primitive.DateTime
-		Grade string `bson:"grade"`
-		Score int    `bson:"score"`
+		Grade string
+		Score int
 	}
 
 	type Restaurant struct {
-		Address      Address  `bson:"address"`
-		Borough      string   `bson:"borough"`
-		Cuisine      string   `bson:"cuisine"`
+		ID           primitive.ObjectID `bson:"_id"`
+		Name         string
+		RestaurantId string `bson:"restaurant_id"`
+		Cuisine      string
+		Address      Address
+		Borough      string
 		Grades       []Grades `bson:"grades"`
-		Name         string   `bson:"name"`
-		RestaurantId string   `bson:"restaurant_id"`
 	}
 
 	// begin findOne
@@ -62,6 +63,7 @@ func main() {
 
 	var result Restaurant
 	err = coll.FindOne(context.TODO(), filter).Decode(&result)
+
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			// This error means your query did not match any documents.

--- a/source/includes/usage-examples/code-snippets/findOne.go
+++ b/source/includes/usage-examples/code-snippets/findOne.go
@@ -55,7 +55,7 @@ func main() {
 		Cuisine      string
 		Address      Address
 		Borough      string
-		Grades       []Grades `bson:"grades"`
+		Grades       []Grades
 	}
 	// end-restaurant-struct
 

--- a/source/includes/usage-examples/code-snippets/findOne.go
+++ b/source/includes/usage-examples/code-snippets/findOne.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -33,11 +34,34 @@ func main() {
 		}
 	}()
 
+	type Address struct {
+		Building    string
+		Coordinates [2]float64
+		Street      string
+		Zipcode     string
+	}
+
+	type Grades struct {
+		Date  primitive.DateTime
+		Grade string `bson:"grade"`
+		Score int    `bson:"score"`
+	}
+
+	type Restaurant struct {
+		Address      Address  `bson:"address"`
+		Borough      string   `bson:"borough"`
+		Cuisine      string   `bson:"cuisine"`
+		Grades       []Grades `bson:"grades"`
+		Name         string   `bson:"name"`
+		RestaurantId string   `bson:"restaurant_id"`
+	}
+
 	// begin findOne
-	coll := client.Database("sample_mflix").Collection("movies")
-	
-	var result bson.M
-	err = coll.FindOne(context.TODO(), bson.D{{"title", "The Room"}}).Decode(&result)
+	coll := client.Database("sample_restaurants").Collection("restaurants")
+	filter := bson.D{{"name", "Bagels N Buns"}}
+
+	var result Restaurant
+	err = coll.FindOne(context.TODO(), filter).Decode(&result)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			// This error means your query did not match any documents.

--- a/source/includes/usage-examples/code-snippets/findOne.go
+++ b/source/includes/usage-examples/code-snippets/findOne.go
@@ -47,6 +47,7 @@ func main() {
 		Score int
 	}
 
+	// start-restaurant-struct
 	type Restaurant struct {
 		ID           primitive.ObjectID `bson:"_id"`
 		Name         string
@@ -56,6 +57,7 @@ func main() {
 		Borough      string
 		Grades       []Grades `bson:"grades"`
 	}
+	// end-restaurant-struct
 
 	// begin findOne
 	coll := client.Database("sample_restaurants").Collection("restaurants")

--- a/source/includes/usage-examples/code-snippets/findOne.go
+++ b/source/includes/usage-examples/code-snippets/findOne.go
@@ -14,6 +14,19 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// start-restaurant-struct
+type Restaurant struct {
+	ID           primitive.ObjectID `bson:"_id"`
+	Name         string
+	RestaurantId string `bson:"restaurant_id"`
+	Cuisine      string
+	Address      interface{}
+	Borough      string
+	Grades       []interface{}
+}
+
+// end-restaurant-struct
+
 func main() {
 	if err := godotenv.Load(); err != nil {
 		log.Println("No .env file found")
@@ -33,31 +46,6 @@ func main() {
 			panic(err)
 		}
 	}()
-
-	type Address struct {
-		Building    string
-		Coordinates [2]float64 `bson:"coord"`
-		Street      string
-		Zipcode     string
-	}
-
-	type Grades struct {
-		Date  primitive.DateTime
-		Grade string
-		Score int
-	}
-
-	// start-restaurant-struct
-	type Restaurant struct {
-		ID           primitive.ObjectID `bson:"_id"`
-		Name         string
-		RestaurantId string `bson:"restaurant_id"`
-		Cuisine      string
-		Address      Address
-		Borough      string
-		Grades       []Grades
-	}
-	// end-restaurant-struct
 
 	// begin findOne
 	coll := client.Database("sample_restaurants").Collection("restaurants")

--- a/source/usage-examples/findOne-output.txt
+++ b/source/usage-examples/findOne-output.txt
@@ -1,1 +1,0 @@
-{"title":"The Room","imdb":{"rating":3.5,"votes":25673,"id":368226}}

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -14,8 +14,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example matches documents in the ``movies`` collection
-in which the ``title`` is "The Room", returning the first document
+The following example matches documents in the ``restaurants`` collection
+in which the ``name`` is "Bagels N Buns", returning the first document
 matched:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
@@ -38,8 +38,8 @@ object that contains the following document:
 
    {
      ...
-     "title": "The Room",
-     "year": 2003,
+     "Name": "Bagels N Buns",
+     "RestaurantId": "40363427",
      ...
    }
 

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -14,7 +14,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example uses the ``Restaurant`` struct as a model:
+The following example uses the ``Restaurant`` struct as a model for documents in 
+the ``restaurants`` collection:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
    :start-after: start-restaurant-struct
@@ -39,8 +40,8 @@ View a `fully runnable example <{+example+}/findOne.go>`__
 Expected Result
 ---------------
 
-After you run the full example, it returns a ``SingleResult``
-object that contains the following document:
+After you run the full example, the returned document is stored in the 
+``result`` type as a ``Restaurant`` struct:
 
 .. code-block:: json
    :copyable: False
@@ -50,7 +51,7 @@ object that contains the following document:
       "ID": "5eb3d668b31de5d588f42950",
       "Name": "Bagels N Buns",
       "RestaurantId": "40363427"
-      "Address": {...},
+      "Address": [...],
       "Borough": "Staten Island",
       "Cuisine": "Delicatessen",
       "Grades": [...]

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -36,12 +36,17 @@ object that contains the following document:
 .. code-block:: json
    :copyable: False
 
+   // results truncated
    {
-     ...
-     "Name": "Bagels N Buns",
-     "RestaurantId": "40363427",
-     ...
+      "ID": "5eb3d668b31de5d588f42950",
+      "Name": "Bagels N Buns",
+      "RestaurantId": "40363427"
+      "Address": {...},
+      "Borough": "Staten Island",
+      "Cuisine": "Delicatessen",
+      "Grades": [...]
    }
+
 
 Additional Information
 ----------------------

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -14,6 +14,15 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
+The following example uses the following ``Restaurant`` struct as a model:
+
+.. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
+   :start-after: start-restaurant-struct
+   :end-before: end-restaurant-struct
+   :language: go 
+   :copyable: 
+   :dedent:
+
 The following example matches documents in the ``restaurants`` collection
 in which the ``name`` is "Bagels N Buns", returning the first document
 matched:

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -14,7 +14,7 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example uses the following ``Restaurant`` struct as a model:
+The following example uses the ``Restaurant`` struct as a model:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
    :start-after: start-restaurant-struct

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -14,8 +14,8 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example uses the ``Restaurant`` struct as a model for documents in 
-the ``restaurants`` collection:
+This example uses the following ``Restaurant`` struct as a model for documents
+in the ``restaurants`` collection:
 
 .. literalinclude:: /includes/usage-examples/code-snippets/findOne.go
    :start-after: start-restaurant-struct
@@ -40,7 +40,7 @@ View a `fully runnable example <{+example+}/findOne.go>`__
 Expected Result
 ---------------
 
-After you run the full example, the returned document is stored in the 
+Running the full example prints the following document, which is stored in the 
 ``result`` variable as a ``Restaurant`` struct:
 
 .. code-block:: json

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -41,7 +41,7 @@ Expected Result
 ---------------
 
 After you run the full example, the returned document is stored in the 
-``result`` type as a ``Restaurant`` struct:
+``result`` variable as a ``Restaurant`` struct:
 
 .. code-block:: json
    :copyable: False

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -32,7 +32,7 @@ matched:
    :end-before: end findOne
    :language: go
    :dedent:
-   :emphasize-lines: 4
+   :emphasize-lines: 5
 
 View a `fully runnable example <{+example+}/findOne.go>`__
 


### PR DESCRIPTION
## Open Questions

- Is there another step I need to take to make sure the "fully runnable example" is correctly linked or is that updated once the new findone.go code snippet file is merged?

## Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-25874>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-25874-struct-tagging-findone/usage-examples/findOne/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
