### PR TITLE
DOCSP-19057 v1.8 backport

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -12,3 +12,179 @@ What's New
    :depth: 1
    :class: singlecol
 
+Learn what's new in:
+
+* :ref:`Version 1.8 <version-1.8>`
+* :ref:`Version 1.7 <version-1.7>`
+* :ref:`Version 1.6 <version-1.6>`
+* :ref:`Version 1.5 <version-1.5>`
+* :ref:`Version 1.4 <version-1.4>`
+* :ref:`Version 1.3 <version-1.3>`
+* :ref:`Version 1.2 <version-1.2>`
+* :ref:`Version 1.1 <version-1.1>`
+* :ref:`Version 1.0 <version-1.0>`
+
+
+.. _version-1.8:
+
+What's New in 1.8
+-----------------
+
+New features of the 1.8 Go driver release include: 
+
+- Full compatibility with MongoDB 5.1.
+
+- Support for :abbr:`KMIP (Key Management Interoperability Protocol)` as a KMS 
+  provider for :abbr:`{+csfle-short+} ({+csfle-long+})`. 
+
+- Redesigned driver connection pool for low operation ``Context`` timeouts and 
+  to reduce connection churn. Behavior changes include: 
+
+  - New connection creation times out at ``connectTimeoutMS``.
+
+  - At most, two new connections can be established at the same time.
+
+- Removal of oppressive and unncessarily gendered language in the Go driver 
+  documentation, code, tests, and spec tests. 
+
+
+.. _version-1.7:
+
+What's New in 1.7
+-----------------
+
+.. important:: Upgrade to Version 1.7.2 or Higher 
+
+  The 1.7.2 Go driver contains a bug fix for a data race that can occur between 
+  creating and checking out connections when ``minPoolSize > 0``. 
+
+New features of the 1.7 Go driver release include:
+
+- Full compatibility with MongoDB 5.0.
+
+- Support for the :readconcern:`"snapshot"` read concern outside of 
+  multi-document transactions for certain read operations.
+
+- Improved ``WriteException`` and ``BulkWriteException`` error messages for
+  schema validation via the ``WriteError.Details`` field.
+
+
+.. _version-1.6:
+
+What's New in 1.6
+-----------------
+
+.. important:: Upgrade to Version 1.6.2 or Higher 
+
+  The 1.6.2 Go driver contains a bug fix for a data race that can occur between 
+  creating and checking out connections when ``minPoolSize > 0``. 
+
+New features of the 1.6 Go driver release include:
+
+- Support for the MongoDB Stable API. For more information, see the 
+  :ref:`Stable API Guide <golang-stable-api>`.
+
+- Support for connections to any MongoDB service that runs behind a load 
+  balancer. 
+  
+- Support for creating time series collections. For more information, see 
+  the :ref:`Time Series Collections Guide <golang-time-series>`.
+
+- ``Let`` option for aggregate expressions.
+
+
+.. _version-1.5:
+
+What's New in 1.5
+-----------------
+
+New features of the 1.5 Go driver release include: 
+
+- Support for Azure and :abbr:`GCP (Google Cloud Platform)` key-management 
+  services with {+csfle-long+}.
+
+- New errors API to detect duplicate-key errors, timeouts, and network 
+  errors.
+
+- Server monitoring to monitor changes on a MongoDB deployment. 
+
+- Errors to prevent unexpected behavior on maps that contain multiple 
+  keys being used as a hint option, as a sort option, or for index creation.
+
+
+.. _version-1.4:
+
+What's New in 1.4
+-----------------
+
+New features of the 1.4 Go driver release include: 
+
+- Full compatibility with MongoDB 4.4.
+
+- Support for stapled and non-stapled OCSP verification.
+
+- New ``tlsDisableOCSPEndpointCheck=true`` URI option to disable sending HTTP 
+  requests if the OCSP responder is not reachable from the driver and there is 
+  no stapled response.
+
+- Additional context to errors encountered during BSON unmarshalling.
+
+- Proper ``Unwrap`` functions for various driver error types. 
+
+
+.. _version-1.3:
+
+What's New in 1.3
+-----------------
+
+New features of the 1.3 Go driver release include: 
+
+- ``mgocompat`` package that exports a BSON registry compatible with 
+  ``globalsign/mgo/bson``, which can be used via the 
+  ``ClientOptions.SetRegistry`` method.
+
+- ``RegisterTypeEncoder`` and ``RegisterHookEncoder`` methods, which 
+  replace the deprecated ``RegisterEncoder`` method. A corresponding change has 
+  been made to replace ``RegisterDecoder``.
+
+
+.. _version-1.2:
+
+What's New in 1.2
+-----------------
+
+New features of the 1.2 Go driver release include: 
+
+- Support for {+csfle-short+}.
+
+- ``bson.MarshalValue`` function, which marshals Go values to BSON.
+
+- ``StringCodec``, which allows non-string fields to be decoded into a 
+  String field in a struct.
+  
+- ``IntCodec``, ``UIntCodec``, ``BoolCodec``, and ``FloatCodec`` added to 
+  ``mgocompat`` to allow codecs to convert between numbers and booleans.
+  
+
+.. _version-1.1:
+
+What's New in 1.1
+-----------------
+
+New features of the 1.1 Go driver release include: 
+
+- Full compatibility with MongoDB 4.2.
+
+- Redesigned lower-level driver implementation to improve maintainability and 
+  performance. 
+
+- Connection Monitoring and Pooling specifications to monitor various connection 
+  and connection pool events with improved utilization.
+
+
+.. _version-1.0:
+
+What's New in 1.0
+-----------------
+
+This release adds no new features.


### PR DESCRIPTION
Port https://github.com/mongodb/docs-golang/pull/185 to v1.8

Staging - https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-19057-whats-new-v1.8/whats-new/