### PR TITLE
Fix code-block indentation

### DIFF
--- a/source/fundamentals/crud/read-operations/query-document.txt
+++ b/source/fundamentals/crud/read-operations/query-document.txt
@@ -42,7 +42,7 @@ Match criteria with a query operator use the following format:
 
 .. code-block:: go
    :copyable: false
-   
+
    filter := bson.D{{"<field>", bson.D{{"<operator>", "<value>"}}}}
 
 The following sections use :ref:`literal values <golang-literal-values>`
@@ -63,7 +63,7 @@ snippet:
    :end-before: end insert docs
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
-   
+
 Each document contains a rating for a type of tea and the vendors that
 carry them, which corresponds to the ``rating``, ``type``, and
 ``vendor`` fields.
@@ -122,7 +122,7 @@ The following example matches documents where the ``type`` is "Oolong":
    the same result:
 
    .. code-block:: go
-   
+
       filter := bson.D{{"type", "Oolong"}}
 
    .. code-block:: go
@@ -152,12 +152,12 @@ than ``7``:
       :language: go
 
       filter := bson.D{{"rating", bson.D{{"$lt", 7}}}}
-      
+
       cursor, err := coll.Find(context.TODO(), filter)
       if err != nil {
          panic(err)
       }
-      
+
       var results []bson.D
       if err = cursor.All(context.TODO(), &results); err != nil {
          panic(err)
@@ -229,24 +229,24 @@ than ``7`` and less than or equal to ``10``:
 For a full list of logical operators, see the :manual:`Logical
 Query Operators </reference/operator/query-logical/>` page.
 
-.. tip:: 
+.. tip::
 
    Multiple match criteria resembling an ``$eq`` comparison operator in
    a literal query return the same value as the ``$and`` logical
    operator. For example, the following query filters produce the same result:
 
    .. code-block:: go
-   
+
       filter := bson.D{{"type", "Oolong"}, {"rating", 7}}
 
    .. code-block:: go
-   
+
       filter := bson.D{
-	    {"$and",
-		    bson.A{
-				bson.D{{"type", "Oolong"}},
-				bson.D{{"rating", 7}},
-			}},
+        {"$and",
+          bson.A{
+            bson.D{{"type", "Oolong"}},
+            bson.D{{"rating", 7}},
+          }},
       }
 
 Element

--- a/source/fundamentals/crud/read-operations/watch.txt
+++ b/source/fundamentals/crud/read-operations/watch.txt
@@ -56,7 +56,7 @@ parameter and a pipeline parameter. To return all changes, pass in an empty Pipe
 Example
 ~~~~~~~
 
-The following example opens a change stream on the ``tea.ratings`` collection and 
+The following example opens a change stream on the ``tea.ratings`` collection and
 outputs all changes:
 
 .. code-block:: go
@@ -76,13 +76,13 @@ outputs all changes:
    }
 
 If you modify the ``tea.ratings`` collection in a separate shell, this code will print
-your changes. Inserting a document with a ``type`` value of ``"White Peony"`` and a 
+your changes. Inserting a document with a ``type`` value of ``"White Peony"`` and a
 ``rating`` value of ``4`` will output the following change event:
-   
+
 .. code-block:: go
    :copyable: false
 
-   map[_id:map[_data:...] clusterTime: {...} documentKey:map[_id:ObjectID("...")] 
+   map[_id:map[_data:...] clusterTime: {...} documentKey:map[_id:ObjectID("...")]
    fullDocument:map[_id:ObjectID("...") rating:4 type:White Peony] ns:
    map[coll:ratings db:tea] operationType:insert]
 
@@ -91,7 +91,7 @@ Modify the Change Stream Output
 
 Use the pipeline parameter to modify the change stream output. This parameter allows you to
 only watch for certain change events. Format the pipeline parameter as an array of documents,
-with each document representing an aggregation stage. 
+with each document representing an aggregation stage.
 
 You can use the following pipeline stages in this parameter:
 
@@ -125,13 +125,13 @@ new delete operations:
       fmt.Println(changeStream.Current)
    }
 
-If you delete the ``tea.ratings`` document with a ``type`` value of 
+If you delete the ``tea.ratings`` document with a ``type`` value of
 ``"White Peony"`` in a separate shell, this code will output the following:
 
 .. code-block:: go
    :copyable: false
-   
-   {"_id": {"_data": "..."},"operationType": "delete","clusterTime": 
+
+   {"_id": {"_data": "..."},"operationType": "delete","clusterTime":
    {"$timestamp":{"t":"...","i":"..."}},"ns": {"db": "tea","coll": "ratings"},
    "documentKey": {"_id": {"$oid":"..."}}}
 
@@ -144,7 +144,7 @@ If you delete the ``tea.ratings`` document with a ``type`` value of
 Modify the Behavior of Watch()
 ------------------------------
 
-Use an opts parameter to modify the behavior of the ``Watch()`` method. 
+Use an opts parameter to modify the behavior of the ``Watch()`` method.
 
 You can specify the following options in the opts parameter:
 
@@ -156,39 +156,39 @@ You can specify the following options in the opts parameter:
 - ``Collation``
 - ``StartAtOperationTime``
 
-For more information on these fields, visit the 
+For more information on these fields, visit the
 :manual:`MongoDB manual </reference/method/Mongo.watch/#mongodb-method-Mongo.watch>`.
 
 Example
 ~~~~~~~
 
-The following example calls the ``Watch()`` method on the ``tea.ratings`` collection. It 
+The following example calls the ``Watch()`` method on the ``tea.ratings`` collection. It
 specifies the ``FullDocument`` opts parameter to output a copy of the entire modified document:
 
 .. code-block:: go
 
-	coll := client.Database("tea").Collection("ratings")
-	opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
+   coll := client.Database("tea").Collection("ratings")
+   opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
 
-	changeStream, err := coll.Watch(context.TODO(), mongo.Pipeline{}, opts)
-	if err != nil {
-		panic(err)
-	}
-	defer changeStream.Close(context.TODO())
+   changeStream, err := coll.Watch(context.TODO(), mongo.Pipeline{}, opts)
+   if err != nil {
+     panic(err)
+   }
+   defer changeStream.Close(context.TODO())
 
-	for changeStream.Next(context.TODO()) {
-		fmt.Println(changeStream.Current)
-	}
+   for changeStream.Next(context.TODO()) {
+     fmt.Println(changeStream.Current)
+   }
 
-If you update the ``rating`` value of the ``"Masala"`` tea from ``10`` to ``9``, 
-this code outputs the following: 
+If you update the ``rating`` value of the ``"Masala"`` tea from ``10`` to ``9``,
+this code outputs the following:
 
 .. code-block:: go
    :copyable: false
 
    {"_id": {"_data": "..."},"operationType": "update","clusterTime": {"$timestamp":
    {"t":"...","i":"..."}},"fullDocument": {"_id": {"$oid":"..."},"type": "Masala","rating":
-   {"$numberInt":"9"}}, "ns": {"db": "tea","coll": "ratings"},"documentKey": {"_id": 
+   {"$numberInt":"9"}}, "ns": {"db": "tea","coll": "ratings"},"documentKey": {"_id":
    {"$oid":"..."}}, "updateDescription": {"updatedFields": {"rating": {"$numberInt":"9"}},
    "removedFields": [],"truncatedArrays": []}}
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

No JIRA ticket

This PR fixes the code-block rST indentation which silently failed to apply syntax highlighting for the specified language. While it's beyond expectations to review each file, to verify the syntax highlighting is applied, you'll need to individually inspect each code block with Chrome Tools for the "go" (or other) style in the code component:

![Screen Shot 2022-11-10 at 12 33 32 AM](https://user-images.githubusercontent.com/52428683/201008783-826546b3-2d86-4c0a-a721-aa767e88bf7f.png)

Staging:

[Query Document](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/110922-fix-code-block-indentation/fundamentals/crud/read-operations/query-document/)

[Watch for Changes](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/110922-fix-code-block-indentation/fundamentals/crud/read-operations/watch/)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
