### PR TITLE
DOCSP-26415: use struct in bulk write usage ex

### DIFF
--- a/source/includes/usage-examples/code-snippets/bulk.go
+++ b/source/includes/usage-examples/code-snippets/bulk.go
@@ -12,6 +12,18 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// start-restaurant-struct
+type Restaurant struct {
+	Name         string
+	RestaurantId string        `bson:"restaurant_id,omitempty"`
+	Cuisine      string        `bson:"cuisine,omitempty"`
+	Address      interface{}   `bson:"address,omitempty"`
+	Borough      string        `bson:"borough,omitempty"`
+	Grades       []interface{} `bson:"grades,omitempty"`
+}
+
+// end-restaurant-struct
+
 func main() {
 	if err := godotenv.Load(); err != nil {
 		log.Println("No .env file found")
@@ -33,12 +45,12 @@ func main() {
 	}()
 
 	// begin bulk
-	coll := client.Database("insertDB").Collection("haikus")
+	coll := client.Database("sample_restaurants").Collection("restaurants")
 	models := []mongo.WriteModel{
-		mongo.NewReplaceOneModel().SetFilter(bson.D{{"title", "Record of a Shriveled Datum"}}).
-			SetReplacement(bson.D{{"title", "Dodging Greys"}, {"text", "When there're no matches, no longer need to panic. You can use upsert"}}),
-		mongo.NewUpdateOneModel().SetFilter(bson.D{{"title", "Dodging Greys"}}).
-			SetUpdate(bson.D{{"$set", bson.D{{"title", "Dodge The Greys"}}}}),
+		mongo.NewReplaceOneModel().SetFilter(bson.D{{"name", "Cafe Tomato"}}).
+			SetReplacement(Restaurant{Name: "Cafe Zucchini", Cuisine: "French"}),
+		mongo.NewUpdateOneModel().SetFilter(bson.D{{"name", "Cafe Zucchini"}}).
+			SetUpdate(bson.D{{"$set", bson.D{{"name", "Zucchini Land"}}}}),
 	}
 	opts := options.BulkWrite().SetOrdered(true)
 

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -14,11 +14,22 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-The following example performs the following in order on the ``haikus``
+This example uses the following ``Restaurant`` struct as a model for documents
+in the ``restaurants`` collection:
+
+.. literalinclude:: /includes/usage-examples/code-snippets/bulk.go
+   :start-after: start-restaurant-struct
+   :end-before: end-restaurant-struct
+   :language: go 
+   :copyable: 
+   :dedent:
+
+The following example performs the following in order on the ``restaurants``
 collection:
 
-- Matches a document in which the ``title`` is "Record of a Shriveled Datum" and replace it with a new document
-- Matches a document in which the ``title`` is "Dodging Greys" and updates that value to "Dodge The Greys"
+- Matches a document in which the ``Name`` is "Cafe Tomato" and replaces it with a new document
+- Matches a document in which the ``Name`` is "Cafe Zucchini" and updates
+  the value to "Zucchini Land"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/bulk.go
    :start-after: begin bulk
@@ -33,15 +44,15 @@ Expected Result
 ---------------
 
 After you run the full example, you can find the following document
-in the ``haikus`` collection:
+in the ``restaurants`` collection:
 
 .. code-block:: json
    :copyable: false
 
    {
-      "_id" : ObjectId("..."),
-      "title" : "Dodge The Greys",
-      "text" : "When there're no matches, no longer need to panic. You can use upsert."
+     "_id": ObjectId("..."),
+     "name": "Zucchini Land",
+     "cuisine": "French"
    }
 
 For an example on how to find a document, see :ref:`golang-find-one`.

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -24,11 +24,14 @@ in the ``restaurants`` collection:
    :copyable: 
    :dedent:
 
+The ``omitempty`` :ref:`struct tag<golang-struct-tags>` omits the corresponding 
+field from the inserted document when left empty.
+
 The following example performs the following in order on the ``restaurants``
 collection:
 
-- Matches a document in which the ``Name`` is "Cafe Tomato" and replaces it with a new document
-- Matches a document in which the ``Name`` is "Cafe Zucchini" and updates
+- Matches a document in which the ``name`` is "Cafe Tomato" and replaces it with a new document
+- Matches a document in which the ``name`` is "Cafe Zucchini" and updates
   the value to "Zucchini Land"
 
 .. literalinclude:: /includes/usage-examples/code-snippets/bulk.go

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -14,7 +14,6 @@ Example
 
 .. include:: /includes/usage-examples/run-example-tip.rst
 
-
 This example uses the following ``Restaurant`` struct as a model for documents
 in the ``restaurants`` collection:
 
@@ -27,7 +26,6 @@ in the ``restaurants`` collection:
 
 The ``omitempty`` :ref:`struct tag<golang-struct-tags>` omits the corresponding 
 field from the inserted document when left empty.
-
 
 The following example inserts a new document to the ``restaurants`` collection:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-26415
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-26415-bulk-ops-structs/usage-examples/bulkWrite/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
