### PR TITLE
DOCSP-26435: use struct in count documents pg

### DIFF
--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -22,6 +22,15 @@ the number of documents in your collection.
 Sample Data
 ~~~~~~~~~~~
 
+The examples in this section use the following ``Tea`` struct as a model for documents
+in the ``ratings`` collection:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
+   :start-after: start-tea-struct
+   :end-before: end-tea-struct
+   :language: go
+   :dedent:
+
 To run the examples in this guide, load the sample data into the ``tea.ratings`` collection with the following
 snippet:
 
@@ -33,8 +42,8 @@ snippet:
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
-Each document contains a rating for a type of tea that corresponds to
-the ``type`` and ``rating`` fields.
+Each document describes a tea type and its rating. These items
+correspond to the ``type`` and ``rating`` fields.
 
 .. _golang-accurate-count:
 
@@ -99,18 +108,18 @@ The following example counts the number of documents where the
       :language: go
 
       filter := bson.D{{"rating", bson.D{{"$lt", 6}}}}
-
+      
       count, err := coll.CountDocuments(context.TODO(), filter)
       if err != nil {
-         panic(err)
+          panic(err)
       }
-      fmt.Printf("Number of ratings less than six: %d\n", count)
+      fmt.Printf("Number of documents with a rating less than six: %d\n", count)
 
    .. output::
       :language: none
       :visible: false
 
-      Number of ratings less than six: 4
+      Number of documents with a rating less than six: 4
 
 .. _golang-count-aggregation:
 
@@ -126,7 +135,7 @@ Example
 The following example performs the following actions:
 
 - Counts the number of documents where the ``rating`` is greater than ``5``
-- Assigns the count to a field called ``total_documents``
+- Assigns the count to the ``counted_documents`` field
 
 .. io-code-block::
    :copyable: true
@@ -135,7 +144,7 @@ The following example performs the following actions:
       :language: go
 
       matchStage := bson.D{{"$match", bson.D{{"rating", bson.D{{"$gt", 5}}}}}}
-      countStage := bson.D{{"$count", "total_documents"}}
+      countStage := bson.D{{"$count", "counted_documents"}}
 
       cursor, err := coll.Aggregate(context.TODO(), mongo.Pipeline{matchStage, countStage})
       if err != nil {
@@ -154,7 +163,7 @@ The following example performs the following actions:
       :language: none
       :visible: false
 
-      [{total_documents 5}]
+      [{counted_documents 5}]
 
 .. _golang-estimated-count:
 
@@ -191,7 +200,7 @@ options with the following methods:
      - | The maximum amount of time that the query can run on the server.
        | Default: ``nil``
 
-Example 
+Example
 ```````
 
 The following example estimates the number of documents in the

--- a/source/includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
@@ -11,6 +11,14 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// start-tea-struct
+type Tea struct {
+	Type   string
+	Rating int32
+}
+
+// end-tea-struct
+
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
@@ -27,28 +35,27 @@ func main() {
 		}
 	}()
 
-	client.Database("tea").Collection("ratings").Drop(context.TODO())
-
 	// begin insert docs
 	coll := client.Database("tea").Collection("ratings")
 	docs := []interface{}{
-		bson.D{{"type", "Masala"}, {"rating", 10}},
-		bson.D{{"type", "Matcha"}, {"rating", 7}},
-		bson.D{{"type", "Assam"}, {"rating", 4}},
-		bson.D{{"type", "Oolong"}, {"rating", 9}},
-		bson.D{{"type", "Chrysanthemum"}, {"rating", 5}},
-		bson.D{{"type", "Earl Grey"}, {"rating", 8}},
-		bson.D{{"type", "Jasmine"}, {"rating", 3}},
-		bson.D{{"type", "English Breakfast"}, {"rating", 6}},
-		bson.D{{"type", "White Peony"}, {"rating", 4}},
+		Tea{Type: "Masala", Rating: 10},
+		Tea{Type: "Matcha", Rating: 7},
+		Tea{Type: "Assam", Rating: 4},
+		Tea{Type: "Oolong", Rating: 9},
+		Tea{Type: "Chrysanthemum", Rating: 5},
+		Tea{Type: "Earl Grey", Rating: 8},
+		Tea{Type: "Jasmine", Rating: 3},
+		Tea{Type: "English Breakfast", Rating: 6},
+		Tea{Type: "White Peony", Rating: 4},
 	}
 
 	result, err := coll.InsertMany(context.TODO(), docs)
+	//end insert docs
+
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
-	//end insert docs
 
 	{
 		// begin count documents
@@ -58,7 +65,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("Number of ratings less than six: %d\n", count)
+		fmt.Printf("Number of documents with a rating less than six: %d\n", count)
 		// end count documents
 	}
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-26435
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-26435-struct-count/fundamentals/crud/read-operations/count/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
