### PR TITLE
fixed spelling error in encrypt field file.

### DIFF
--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -57,7 +57,7 @@ The MongoDB manual contains detailed information on the following {+qe+} topics:
 
 {+csfle-long+} was introduced in MongoDB version v4.2 and supports searching encrypted
 fields for equality. {+csfle-short+} differs from {+qe+} in that it requires
-that the encrypted fields you want to search must be determinstically encrypted.
+that the encrypted fields you want to search must be deterministically encrypted.
 When you deterministically encrypt a value, the same input value produces
 the same output value. While deterministic encryption provides greater
 support for read operations, encrypted data with low :wikipedia:`cardinality <Cardinality>`


### PR DESCRIPTION
# Pull Request Info

there was a spelling mistake in the [encrypt fields documentation](https://www.mongodb.com/docs/drivers/go/current/fundamentals/encrypt-fields/#client-side-field-level-encryption)

I have fixed it.



[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [YES] Is this free of any warnings or errors in the RST?
- [YES] Did you run a spell-check?
- [YES] Did you run a grammar-check?
- [YES] Are all the links working?
