### PR TITLE
DOCSP-26363: add link to AWS Lambda docs

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -9,6 +9,7 @@ Fundamentals
    :maxdepth: 1
 
    /fundamentals/connection
+   Connect to MongoDB Atlas from AWS Lambda <https://www.mongodb.com/docs/atlas/manage-connections-aws-lambda/>
    /fundamentals/stable-api
    /fundamentals/context
    /fundamentals/auth

--- a/source/includes/fundamentals-sections.rst
+++ b/source/includes/fundamentals-sections.rst
@@ -2,6 +2,7 @@ Learn how to perform the following tasks using the Go driver in the
 Fundamentals section:
 
 - :ref:`Connect to MongoDB <golang-connection-guide>`
+- :atlas:`Connect to MongoDB Atlas from AWS Lambda </manage-connections-aws-lambda/>`
 - :ref:`Specify an API Version <golang-stable-api>`
 - :ref:`How the Driver Uses Context <golang-context>`
 - :ref:`Authenticate with MongoDB <golang-authentication-mechanisms>`

--- a/source/includes/fundamentals-sections.rst
+++ b/source/includes/fundamentals-sections.rst
@@ -12,7 +12,7 @@ Fundamentals section:
 - :ref:`Perform Aggregations <golang-aggregation>`
 - :ref:`Construct Indexes <golang-indexes>`
 - :ref:`Specify Collations to Order Results <golang-collations>`
-- :ref:`Use Driver Events in your Code <golang-monitoring>`
+- :ref:`Use Driver Events in Your Code <golang-monitoring>`
 - :ref:`Store and Retrieve Files in MongoDB <golang-gridfs>`
 - :ref:`Use a Time Series Collection <golang-time-series>`
 - :ref:`Encrypt Fields <golang-fle>`
@@ -20,4 +20,3 @@ Fundamentals section:
 
 .. - :doc:`Use the Driver's Data Formats </fundamentals/data-formats>`
 .. - :doc:`Record Events in the Driver </fundamentals/logging>`
-.. - :doc:`Use Driver Events in your Code </fundamentals/monitoring>`


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-26363>
Staging - 

[Fundamentals landing page
](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-26363-link-to-lambda/fundamentals/)

Also, check the left nav item.

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
