### PR TITLE
DOCSP-26447: use struct in write ops

### DIFF
--- a/source/fundamentals/crud/write-operations.txt
+++ b/source/fundamentals/crud/write-operations.txt
@@ -10,7 +10,7 @@ Write Operations
 - :ref:`golang-delete-guide`
 - :ref:`golang-change-document`
 - :ref:`golang-update-arrays`
-- :ref:`golang-upsert`
+- :ref:`golang-upsert-guide`
 - :ref:`golang-bulk`
 
 .. toctree::

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -24,23 +24,35 @@ perform multiple operations with one call to the database.
 Sample Data
 ~~~~~~~~~~~
 
-To run the example in this guide, load the sample data into the
-``tea.ratings`` collection with the following
-snippet:
+The examples in this guide use the following ``Book`` struct as a model for documents
+in the ``books`` collection:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
+   :start-after: start-book-struct
+   :end-before: end-book-struct
+   :language: go
+   :dedent:
+
+To run the examples in this guide, load the sample data into the
+``db.books`` collection with the following snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
    :dedent:
-   :start-after: begin insert docs
-   :end-before: end insert docs
+   :start-after: begin insertDocs
+   :end-before: end insertDocs
 
-.. include:: /includes/fundamentals/tea-sample-data-ending.rst
+Each document contains a description of a book that
+includes the title, author, and page length corresponding to
+the ``title``, ``author``, and ``length`` fields in each document.
+
+.. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
 Bulk Write
 ----------
 
-To perform a bulk operation, pass a slice of :ref:`WriteModel
-<golang-write-model>` documents to the ``BulkWrite()`` method. 
+To perform a bulk operation, pass an array of :ref:`WriteModel
+<golang-write-model>` documents to the ``BulkWrite()`` method.
 
 Modify Behavior
 ~~~~~~~~~~~~~~~
@@ -176,8 +188,7 @@ Example
 ```````
 
 The following example creates a ``ReplaceOneModel`` to replace a
-document where the ``type`` is "Earl Grey" with a document where the
-``type`` is "Matcha" and the ``rating`` is ``8``:
+document where the ``title`` is "Lucy" with a new document:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
@@ -225,7 +236,7 @@ Example
 ```````
 
 The following example creates an ``UpdateOneModel`` to decrement a
-documents ``rating`` by ``2`` if their ``type`` is "Masala":
+document's ``length`` by ``15`` if the ``author`` is "Elena Ferrante":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
@@ -263,7 +274,7 @@ Example
 ```````
 
 The following example creates a ``DeleteManyModel`` to delete
-documents where the ``rating`` is greater than ``7``:
+documents where the ``length`` is greater than ``400``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go
@@ -306,9 +317,10 @@ Example
 The following example performs the following actions in any order: 
 
 - Inserts two documents.
-- Replaces a document where the type is "Earl Grey" with a new document.
-- Increments all documents ``rating`` by ``3`` if their current rating is less than ``7``.
-- Deletes all documents where the rating is ``9``.
+- Replaces a document where the ``title`` is "My Brilliant Friend" with a new document.
+- Increments every document's ``length`` by ``10`` if the current
+  ``length`` value is less than ``200``.
+- Deletes all documents where the ``author`` field value includes "Jam".
 
 .. io-code-block::
    :copyable: true
@@ -317,16 +329,16 @@ The following example performs the following actions in any order:
       :language: go
 
       models := []mongo.WriteModel{
-         mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Oolong"}, {"rating", 9}}),
-         mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Assam"}, {"rating", 6}}),
-         mongo.NewReplaceOneModel().SetFilter(bson.D{{"type", "Earl Grey"}}).
-            SetReplacement(bson.D{{"type", "Matcha"}, {"rating", 4}}),
-         mongo.NewUpdateManyModel().SetFilter(bson.D{{"rating", bson.D{{"$lt", 7}}}}).
-            SetUpdate(bson.D{{"$inc", bson.D{{"rating", 3}}}}),
-         mongo.NewDeleteManyModel().SetFilter(bson.D{{"rating", 9}}),
+        mongo.NewInsertOneModel().SetDocument(Book{Title: "Middlemarch", Author: "George Eliot", Length: 904}),
+        mongo.NewInsertOneModel().SetDocument(Book{Title: "Pale Fire", Author: "Vladimir Nabokov", Length: 246}),
+        mongo.NewReplaceOneModel().SetFilter(bson.D{{"title", "My Brilliant Friend"}}).
+      	  SetReplacement(Book{Title: "Atonement", Author: "Ian McEwan", Length: 351}),
+        mongo.NewUpdateManyModel().SetFilter(bson.D{{"length", bson.D{{"$lt", 200}}}}).
+      	  SetUpdate(bson.D{{"$inc", bson.D{{"length", 10}}}}),
+        mongo.NewDeleteManyModel().SetFilter(bson.D{{"author", bson.D{{"$regex", "Jam"}}}}),
       }
       opts := options.BulkWrite().SetOrdered(false)
-
+      
       results, err := coll.BulkWrite(context.TODO(), models, opts)
       if err != nil {
          panic(err)
@@ -341,8 +353,8 @@ The following example performs the following actions in any order:
       :visible: false
 
       Number of documents inserted: 2
-      Number of documents replaced or updated: 3
-      Number of documents deleted: 2
+      Number of documents replaced or updated: 2
+      Number of documents deleted: 1
 
 The following documents are present in the ``ratings`` collection after
 the bulk operation:
@@ -350,8 +362,9 @@ the bulk operation:
 .. code-block:: none
    :copyable: false
 
-   [{_id ObjectID("...")} {type Masala} {rating 10}]
-   [{_id ObjectID("...")} {type Matcha} {rating 7}]
+   {"title":"Atonement","author":"Ian McEwan","length":351}
+   {"title":"Middlemarch","author":"George Eliot","length":904}
+   {"title":"Pale Fire","author":"Vladimir Nabokov","length":246}
 
 Additional Information
 ----------------------

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -274,7 +274,7 @@ Example
 ```````
 
 The following example creates a ``DeleteManyModel`` to delete
-documents where the ``length`` is greater than ``400``:
+documents where the ``length`` is greater than ``300``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/bulkOps.go
    :language: go

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -104,7 +104,7 @@ The following example performs the following with the ``DeleteMany()``
 method:
 
 - Matches and deletes documents where the ``length`` is greater than ``300``
-- Specifies the method to use the ``_id`` as the index
+- Instructs the method to use the ``_id`` as the index
 
 .. io-code-block::
    :copyable: true

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -149,7 +149,9 @@ following guides:
 - :ref:`golang-query-document`
 
 To learn about how the driver uses Context, see :ref:`golang-context`.
+
 To learn more about specifying hints, see :ref:`golang-indexes`.
+
 To learn more about collations, see :ref:`golang-collations`.
 
 API Documentation

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -21,9 +21,17 @@ collections using delete operations.
 Sample Data
 ~~~~~~~~~~~
 
-To run the example in this guide, load these documents into the
-``tea.ratings`` collection with the following
-snippet:
+The examples in this guide use the following ``Book`` struct as a model for documents
+in the ``books`` collection:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/delete.go
+   :start-after: start-book-struct
+   :end-before: end-book-struct
+   :language: go
+   :dedent:
+
+To run the examples in this guide, load the sample data into the
+``db.books`` collection with the following snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/delete.go
    :language: go
@@ -31,10 +39,11 @@ snippet:
    :start-after: begin insertDocs
    :end-before: end insertDocs
 
-.. include:: /includes/fundamentals/automatic-db-coll-creation.rst
+Each document contains a description of a book that
+includes the title, author, and page length corresponding to
+the ``title``, ``author``, and ``length`` fields in each document.
 
-Each document contains a rating for a type of tea, which corresponds to
-the ``type`` and ``rating`` fields.
+.. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
 Delete Operations
 -----------------
@@ -94,7 +103,7 @@ Example
 The following example performs the following with the ``DeleteMany()``
 method:
 
-- Matches and deletes documents where the ``rating`` is greater than ``8``
+- Matches and deletes documents where the ``length`` is greater than ``300``
 - Specifies the method to use the ``_id`` as the index
 
 .. io-code-block::
@@ -103,7 +112,7 @@ method:
    .. input::
       :language: go
 
-      filter := bson.D{{"rating", bson.D{{"$gt", 8}}}}
+      filter := bson.D{{"length", bson.D{{"$gt", 300}}}}
       opts := options.Delete().SetHint(bson.D{{"_id", 1}})
 
       result, err := coll.DeleteMany(context.TODO(), filter, opts)
@@ -140,9 +149,8 @@ following guides:
 - :ref:`golang-query-document`
 
 To learn about how the driver uses Context, see :ref:`golang-context`.
-
-.. To learn more about specifying hints, see <TODO: Indexes>.
-.. To learn more about collations, see  <TODO: Collations>.
+To learn more about specifying hints, see :ref:`golang-indexes`.
+To learn more about collations, see :ref:`golang-collations`.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -15,8 +15,8 @@ Update Arrays in a Document
 Overview
 --------
 
-In this guide, you can learn how to update array elements in a document
-or multiple documents.
+In this guide, you can learn how to update array elements in one or more
+documents.
 
 To update elements in an array, perform the following actions:
 
@@ -27,8 +27,8 @@ To update elements in an array, perform the following actions:
 Sample Data
 ~~~~~~~~~~~
 
-The examples in this guide use the following ``Book`` struct as a model for documents
-in the ``books`` collection:
+The examples in this guide use the following ``Drink`` struct as a model for documents
+in the ``drinks`` collection:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
    :start-after: start-drink-struct
@@ -49,7 +49,7 @@ To run the examples in this guide, load the sample data into the
    :end-before: end insertDocs
 
 Each document contains a description of a drink that
-includes the drink's description, available sizes (in ounces), and available
+includes the drink's description, available sizes in ounces, and available
 preparation styles, corresponding to the ``description``, ``sizes``, and
 ``styles`` fields in each document.
 

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -15,7 +15,8 @@ Update Arrays in a Document
 Overview
 --------
 
-In this guide, you can learn how to update array elements in a document.
+In this guide, you can learn how to update array elements in a document
+or multiple documents.
 
 To update elements in an array, perform the following actions:
 
@@ -26,15 +27,31 @@ To update elements in an array, perform the following actions:
 Sample Data
 ~~~~~~~~~~~
 
+The examples in this guide use the following ``Book`` struct as a model for documents
+in the ``books`` collection:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
+   :start-after: start-drink-struct
+   :end-before: end-drink-struct
+   :language: go
+   :dedent:
+
+The ``truncate`` :ref:`struct tag<golang-struct-tags>` allows the driver
+to truncate types such as ``float64`` to ``int32`` when unmarshalling.
+
 To run the examples in this guide, load the sample data into the
-``quantity.tea`` collection with the following
-snippet:
+``db.drinks`` collection with the following snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/updateArray.go
    :language: go
    :dedent:
-   :start-after: begin insert docs
-   :end-before: end insert docs
+   :start-after: begin insertDocs
+   :end-before: end insertDocs
+
+Each document contains a description of a drink that
+includes the drink's description, available sizes (in ounces), and available
+preparation styles, corresponding to the ``description``, ``sizes``, and
+``styles`` fields in each document.
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
 
@@ -42,8 +59,6 @@ The following examples use the ``FindOneAndUpdate()`` method to
 retrieve and update a document and to return the state of the document
 after the update occurs. If you want to update multiple documents with
 an array field, use the ``UpdateMany()`` method.
-
-.. include:: /includes/fundamentals/truncated-id.rst
 
 Specify Array Elements
 ----------------------
@@ -71,8 +86,9 @@ Example
 
 This example performs the following actions:
 
-- Matches array elements in ``qty`` where the value is greater than ``10``.
-- Decrements the first array value matched by ``5``.
+- Matches array elements in ``sizes`` where the value is less than or
+  equal to ``16``.
+- Decrements the first array value matched by ``2``.
 
 .. io-code-block::
    :copyable: true
@@ -80,28 +96,31 @@ This example performs the following actions:
    .. input::
       :language: go
 
-      filter := bson.D{{"qty", bson.D{{"$gt", 10}}}}
-      update := bson.D{{"$inc", bson.D{{"qty.$", -5}}}}
-      opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
 
-      var updatedDoc bson.D
+      filter := bson.D{{"sizes", bson.D{{"$lte", 16}}}}
+      update := bson.D{{"$inc", bson.D{{"sizes.$", -2}}}}
+      opts := options.FindOneAndUpdate().
+          SetReturnDocument(options.After)
+      
+      var updatedDoc Drink
       err := coll.FindOneAndUpdate(context.TODO(), filter, update, opts).Decode(&updatedDoc)
       if err != nil {
-         panic(err)
+          panic(err)
       }
-
-      fmt.Println(updatedDoc)
+      
+      res, _ := bson.MarshalExtJSON(updatedDoc, false, false)
+      fmt.Println(string(res))
 
    .. output::
       :language: none
       :visible: false
 
-      [{_id ObjectID(“…”)} {type Masala} {qty [10 12 18]}]
+      {"description":"Matcha Latte","sizes":[10,16,20],"styles":["iced","hot","extra hot"]}
 
 .. note::
 
-   The query filter matches the values ``15`` and ``12``. Since ``15``
-   is the first element matched, it is updated. If you want to update
+   The query filter matches the values ``12`` and ``16``. Since the
+   operation matches ``12`` first, it is decremented. If you want to update
    both matched values, see :ref:`golang-multiple-elements`.
 
 .. _golang-multiple-elements:
@@ -123,9 +142,10 @@ Example
 
 This example performs the following actions:
 
-- Creates an array filter with an identifier called ``smaller`` to match elements less than ``18``.
+- Creates an array filter with an identifier called ``hot_options`` to match
+  array elements that contain "hot".
 - Applies the array filter using the ``SetArrayFilters()`` method.
-- Increments every matched element by ``7``.
+- Removes these array elements.
 
 .. io-code-block::
    :copyable: true
@@ -133,23 +153,26 @@ This example performs the following actions:
    .. input::
       :language: go
 
-      identifier := []interface{}{bson.D{{"smaller", bson.D{{"$lt", 18}}}}}
-      update := bson.D{{"$inc", bson.D{{"qty.$[smaller]", 7}}}}
-      opts := options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{Filters: identifier}).SetReturnDocument(options.After)
-
-      var updatedDoc bson.D
+      identifier := []interface{}{bson.D{{"hotOptions", bson.D{{"$regex", "hot"}}}}}
+      update := bson.D{{"$unset", bson.D{{"styles.$[hotOptions]", ""}}}}
+      opts := options.FindOneAndUpdate().
+          SetArrayFilters(options.ArrayFilters{Filters: identifier}).
+          SetReturnDocument(options.After)
+      
+      var updatedDoc Drink
       err := coll.FindOneAndUpdate(context.TODO(), bson.D{}, update, opts).Decode(&updatedDoc)
       if err != nil {
-         panic(err)
+          panic(err)
       }
-
-      fmt.Println(updatedDoc)
+      
+      res, _ := bson.MarshalExtJSON(updatedDoc, false, false)
+      fmt.Println(string(res))
 
    .. output::
       :language: none
       :visible: false
 
-      [{_id ObjectID("...")} {type Masala} {qty [22 19 18]}]
+      {"description":"Matcha Latte","sizes":[12,16,20],"styles":["iced","",""]}
 
 .. _golang-all-elements:
 
@@ -167,7 +190,8 @@ To update all the array elements, use the all positional ``$[]`` operator.
 Example
 ```````
 
-This example multiplies every array element in ``qty`` by ``2``:
+This example multiplies every array element in ``sizes`` by ``29.57``
+to convert from ounces to milliliters:
 
 .. io-code-block::
    :copyable: true
@@ -175,22 +199,24 @@ This example multiplies every array element in ``qty`` by ``2``:
    .. input::
       :language: go
 
-      update := bson.D{{"$mul", bson.D{{"qty.$[]", 2}}}}
-      opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
-
-      var updatedDoc bson.D
+      update := bson.D{{"$mul", bson.D{{"sizes.$[]", 29.57}}}}
+      opts := options.FindOneAndUpdate().
+          SetReturnDocument(options.After)
+      
+      var updatedDoc Drink
       err := coll.FindOneAndUpdate(context.TODO(), bson.D{}, update, opts).Decode(&updatedDoc)
       if err != nil {
-         panic(err)
+          panic(err)
       }
-
-      fmt.Println(updatedDoc)
+      
+      res, _ := bson.MarshalExtJSON(updatedDoc, false, false)
+      fmt.Println(string(res))
 
    .. output::
       :language: none
       :visible: false
 
-      [{_id ObjectID("...")} {type Masala} {qty [30 24 36]}]
+      {"description":"Matcha Latte","sizes":[354,473,591],"styles":["iced","hot","extra hot"]}
 
 Additional Information
 ----------------------

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -142,7 +142,7 @@ Example
 
 This example performs the following actions:
 
-- Creates an array filter with an identifier called ``hot_options`` to match
+- Creates an array filter with an identifier called ``hotOptions`` to match
   array elements that contain "hot".
 - Applies the array filter using the ``SetArrayFilters()`` method.
 - Removes these array elements.

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -212,10 +212,10 @@ Assume you want to insert the following documents:
 .. code-block:: json
    :copyable: false
 
-   { "_id": 1, "name": "Tanzania" }
-   { "_id": 2, "name": "Lithuania" }
-   { "_id": 1, "name": "Vietnam" }
-   { "_id": 3, "name": "Argentina" }
+   { "_id": 1, "title": "Where the Wild Things Are" }
+   { "_id": 2, "title": "The Very Hungry Caterpillar" }
+   { "_id": 1, "title": "Blueberries for Sal" }
+   { "_id": 3, "title": "Goodnight Moon" }
 
 If you attempt to insert these documents with default ``InsertManyOptions``, a
 ``BulkWriteException`` occurs at the third document because of the repeated
@@ -233,18 +233,18 @@ inserted into your collection.
       .. input::
          :language: go
    
-         type Country struct {
-             ID   int `bson:"_id"`
-             Name string
+         type Book struct {
+             ID    int `bson:"_id"`
+             Title string
          }
 
          ...
 
          docs := []interface{}{
-             Country{ID: 1, Name: "Tanzania"},
-             Country{ID: 2, Name: "Lithuania"},
-             Country{ID: 1, Name: "Vietnam"},
-             Country{ID: 3, Name: "Argentina"},
+             Book{ID: 1, Title: "Where the Wild Things Are"},
+             Book{ID: 2, Title: "The Very Hungry Caterpillar"},
+             Book{ID: 1, Title: "Blueberries for Sal"},
+             Book{ID: 3, Title: "Goodnight Moon"},
          }
    
          result, err := coll.InsertMany(context.TODO(), docs)
@@ -269,8 +269,8 @@ inserted into your collection.
    .. code-block:: json
       :copyable: false
    
-      { "_id": 1, "name": "Tanzania" }
-      { "_id": 2, "name": "Lithuania" }
+      { "_id": 1, "title": "Where the Wild Things Are" }
+      { "_id": 2, "title": "The Very Hungry Caterpillar" }
 
 
 Additional Information

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -25,9 +25,8 @@ the ``InsertOne()`` method, or insert multiple documents using either
 the ``InsertMany()`` or ``BulkWrite()`` method.
 
 The following sections focus on ``InsertOne()`` and ``InsertMany()``.
-
-..
-  For an example on how to use the ``BulkWrite()`` method, see :ref:`golang-bulk-ops-usage-example`.
+To learn how to use the ``BulkWrite()`` method, see the
+:ref:`golang-bulk` guide.
 
 The ``_id`` Field
 -----------------
@@ -36,8 +35,8 @@ In MongoDB, each document *must* contain a unique ``_id`` field.
 
 The two options for managing this field are:
 
-- You can manage this field yourself, ensuring each value you use is unique.
-- You can let the driver automatically generate unique ``ObjectId`` values. The
+- Managing this field yourself, ensuring that each value you use is unique.
+- Letting the driver automatically generate unique ``ObjectId`` values. The
   driver generates unique ``ObjectId`` values for documents that you do
   not explicitly specify an ``_id``.
 
@@ -67,9 +66,17 @@ the new document.
 Example
 ~~~~~~~
 
+This example uses the following ``Book`` struct as a model for documents
+in the ``books`` collection:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/insertOptions.go
+   :start-after: start-book-struct
+   :end-before: end-book-struct
+   :language: go
+   :dedent:
+
 The following example creates and inserts a document into the
-``favorite_books`` collection using the
-``InsertOne()`` method:
+``books`` collection using the ``InsertOne()`` method:
 
 .. io-code-block::
    :copyable: true
@@ -77,8 +84,8 @@ The following example creates and inserts a document into the
    .. input::
       :language: go
 
-      coll := client.Database("myDB").Collection("favorite_books")
-      doc := bson.D{{"title", "Invisible Cities"}, {"author", "Italo Calvino"}, {"year_published", 1974}}
+      coll := client.Database("db").Collection("books")
+      doc := Book{Title: "Atonement", Author: "Ian McEwan"}
 
       result, err := coll.InsertOne(context.TODO(), doc)
 
@@ -93,7 +100,7 @@ The following example creates and inserts a document into the
 Modify ``InsertOne`` Behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can modify the behavior of ``InsertOne()`` by constructing and passing
-an optional ``InsertOneOptions`` struct.  The available options to tune with
+an optional ``InsertOneOptions`` struct.  The available options to set with
 ``InsertOneOptions`` are:
 
 .. list-table::
@@ -130,26 +137,25 @@ instance that contains the ``_id`` fields of the inserted documents.
 Example
 ~~~~~~~
 
-The following example creates and inserts some documents into the
-``favorite_books`` collection using the ``InsertMany()`` method:
+The following example creates and inserts multiple documents into the
+``books`` collection using the ``InsertMany()`` method:
 
 .. code-block:: go
 
    coll := client.Database("myDB").Collection("favorite_books")
    docs := []interface{}{
-       bson.D{{"title", "My Brilliant Friend"}, {"author", "Elena Ferrante"}, {"year_published", 2012}},
-       bson.D{{"title", "Lucy"}, {"author", "Jamaica Kincaid"}, {"year_published", 2002}},
-       bson.D{{"title", "Cat's Cradle"}, {"author", "Kurt Vonnegut Jr."}, {"year_published", 1998}},
+       Book{Title: "Cat's Cradle", Author: "Kurt Vonnegut Jr."},
+       Book{Title: "In Memory of Memory", Author: "Maria Stepanova"},
+       Book{Title: "Pride and Prejudice", Author: "Jane Austen"},
    }
-
+   
    result, err := coll.InsertMany(context.TODO(), docs)
-   list_ids := result.InsertedIDs
-   fmt.Printf("Documents inserted: %v\n", len(list_ids))
-
-   for _, id := range list_ids {
-	   fmt.Printf("Inserted document with _id: %v\n", id)
+   fmt.Printf("Documents inserted: %v\n", len(result.InsertedIDs))
+   
+   for _, id := range result.InsertedIDs {
+       fmt.Printf("Inserted document with _id: %v\n", id)
    }
-
+   
 Your output should look like this:
 
 .. code-block:: none
@@ -164,8 +170,8 @@ Modify ``InsertMany`` Behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can modify the behavior of ``InsertMany()`` by constructing
-and passing an optional ``InsertOneOptions`` struct. The available options
-to tune with ``InsertOneOptions`` are:
+and passing an optional ``InsertManyOptions`` struct. The available options
+to set with ``InsertManyOptions`` are:
 
 .. list-table::
    :header-rows: 1
@@ -206,10 +212,10 @@ Assume you want to insert the following documents:
 .. code-block:: json
    :copyable: false
 
-   { "_id": 1, "country": "Tanzania" }
-   { "_id": 2, "country": "Lithuania" }
-   { "_id": 1, "country": "Vietnam" }
-   { "_id": 3, "country": "Argentina" }
+   { "_id": 1, "name": "Tanzania" }
+   { "_id": 2, "name": "Lithuania" }
+   { "_id": 1, "name": "Vietnam" }
+   { "_id": 3, "name": "Argentina" }
 
 If you attempt to insert these documents with default ``InsertManyOptions``, a
 ``BulkWriteException`` occurs at the third document because of the repeated
@@ -221,44 +227,50 @@ inserted into your collection.
    You can get an acknowledgement of successful document insertion even
    if a BulkWriteException occurs:
 
-.. io-code-block::
-   :copyable: true
+   .. io-code-block::
+      :copyable: true
+   
+      .. input::
+         :language: go
+   
+         type Country struct {
+             ID   int `bson:"_id"`
+             Name string
+         }
 
-   .. input::
-      :language: go
+         ...
 
-      docs := []interface{}{
-         bson.D{{"_id", 1}, {"country", "Tanzania"}},
-         bson.D{{"_id", 2}, {"country", "Lithuania"}},
-         bson.D{{"_id", 1}, {"country", "Vietnam"}},
-         bson.D{{"_id", 3}, {"country", "Argentina"}},
-      }
-
-      result, err := coll.InsertMany(context.TODO(), docs)
-      list_ids := result.InsertedIDs
-      if err != nil {
-         fmt.Printf("A bulk write error occurred, but %v documents were still inserted.\n", len(list_ids))
-      }
-
-      for _, id := range list_ids {
-         fmt.Printf("Inserted document with _id: %v\n", id)
-      }
-
-   .. output::
-      :language: none
-      :visible: false
-
-      A bulk write error occurred, but 2 documents were still inserted.
-      Inserted document with _id: 1
-      Inserted document with _id: 2
-
-If you look inside your collection, you should be able to see the following documents:
-
-.. code-block:: json
-   :copyable: false
-
-   { "_id": 1, "country": "Tanzania" }
-   { "_id": 2, "country": "Lithuania" }
+         docs := []interface{}{
+             Country{ID: 1, Name: "Tanzania"},
+             Country{ID: 2, Name: "Lithuania"},
+             Country{ID: 1, Name: "Vietnam"},
+             Country{ID: 3, Name: "Argentina"},
+         }
+   
+         result, err := coll.InsertMany(context.TODO(), docs)
+         if err != nil {
+             fmt.Printf("A bulk write error occurred, but %v documents were still inserted.\n", len(result.InsertedIDs))
+         }
+   
+         for _, id := range result.InsertedIDs {
+             fmt.Printf("Inserted document with _id: %v\n", id)
+         }
+   
+      .. output::
+         :language: none
+         :visible: false
+   
+         A bulk write error occurred, but 2 documents were still inserted.
+         Inserted document with _id: 1
+         Inserted document with _id: 2
+   
+   If you look inside your collection, you should be able to see the following documents:
+   
+   .. code-block:: json
+      :copyable: false
+   
+      { "_id": 1, "name": "Tanzania" }
+      { "_id": 2, "name": "Lithuania" }
 
 
 Additional Information
@@ -274,8 +286,7 @@ To learn more about performing the operations mentioned, see the
 following guides:
 
 - :ref:`golang-query-document`
-
-.. - :doc:`Bulk Operations </fundamentals/crud/write-operations/bulk>`
+- :ref:`golang-bulk`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/write-operations/upsert.txt
+++ b/source/fundamentals/crud/write-operations/upsert.txt
@@ -17,26 +17,35 @@ Insert or Update in a Single Operation
 Overview
 --------
 
-In this guide, you can learn how to specify an :ref:`upsert
+In this guide, you can learn how to perform an :ref:`upsert
 <golang-upsert-definition>`.
 
 Sample Data
 ~~~~~~~~~~~
 
-To run the example in this guide, load the sample data into the
-``tea.ratings`` collection with the following
-snippet:
+The examples in this guide use the following ``Plant`` struct as a model for documents
+in the ``plants`` collection:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/CRUD/upsert.go
+   :start-after: start-plant-struct
+   :end-before: end-plant-struct
+   :language: go
+   :dedent:
+
+To run the examples in this guide, load the sample data into the
+``db.plants`` collection with the following snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CRUD/upsert.go
    :language: go
    :dedent:
-   :start-after: begin insert docs
-   :end-before: end insert docs
+   :start-after: begin insertDocs
+   :end-before: end insertDocs
+
+Each document contains a description of an individual plant that
+includes the species, plant ID, and height corresponding to
+the ``species``, ``plant_id``, and ``height`` fields in each document.
 
 .. include:: /includes/fundamentals/automatic-db-coll-creation.rst
-
-Each document contains a rating for a type of tea that corresponds to
-the ``type`` and ``rating`` fields.
 
 Upsert
 ------
@@ -50,8 +59,8 @@ decision for us with an **upsert** option.
 
 An upsert performs one of the following actions:
 
-- Update documents that match your query filter
-- Insert a document if there are no matches to your query filter
+- Updates documents that match your query filter
+- Inserts a new document if there are no matches to your query filter
 
 You can specify an upsert by passing ``true`` to the ``SetUpsert()``
 method in the options of the following write operation methods:
@@ -74,9 +83,10 @@ Example
 
 The following example performs the following actions:
 
-- Matches documents where the ``type`` is "Oolong"
-- Updates the ``rating`` of the matched document to ``8``
-- Inserts this document if there are no matches to your query filter
+- Matches documents where the ``species`` is "Ledebouria socialis" and
+  the ``plant_id`` is ``3``
+- Updates the ``height`` of the matched document to ``8.3``
+- Inserts this document if there are no matches to the query filter
 
 .. io-code-block::
    :copyable: true
@@ -84,15 +94,15 @@ The following example performs the following actions:
    .. input::
       :language: go
 
-      filter := bson.D{{"type", "Oolong"}}
-      update := bson.D{{"$set", bson.D{{"rating", 8}}}}
+      filter := bson.D{{"species", "Ledebouria socialis"}, {"plant_id", 3}}
+      update := bson.D{{"$set", bson.D{{"species", "Ledebouria socialis"}, {"plant_id", 3}, {"height", 8.3}}}}
       opts := options.Update().SetUpsert(true)
-
+      
       result, err := coll.UpdateOne(context.TODO(), filter, update, opts)
       if err != nil {
-         panic(err)
+          panic(err)
       }
-
+      
       fmt.Printf("Number of documents updated: %v\n", result.ModifiedCount)
       fmt.Printf("Number of documents upserted: %v\n", result.UpsertedCount)
 
@@ -102,6 +112,18 @@ The following example performs the following actions:
 
       Number of documents updated: 0
       Number of documents upserted: 1
+
+If you query the ``plants`` collection to view all documents, you can
+see that since the query filter did not match any documents, a new
+document was inserted with the specified fields:
+
+.. code-block:: none
+   :copyable: false
+
+   {"species":"Polyscias fruticosa","plant_id":1,"height":27.6}
+   {"species":"Polyscias fruticosa","plant_id":2,"height":34.9}
+   {"species":"Ledebouria socialis","plant_id":1,"height":11.4}
+   {"species":"Ledebouria socialis","plant_id":3,"height":8.3}
 
 Additional Information
 ----------------------

--- a/source/fundamentals/crud/write-operations/upsert.txt
+++ b/source/fundamentals/crud/write-operations/upsert.txt
@@ -1,3 +1,5 @@
+.. _golang-upsert-guide:
+
 ======================================
 Insert or Update in a Single Operation
 ======================================

--- a/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
@@ -11,6 +11,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// start-book-struct
+type Book struct {
+	Title  string
+	Author string
+	Length int32
+}
+
+// end-book-struct
+
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
@@ -27,28 +36,26 @@ func main() {
 		}
 	}()
 
-	client.Database("tea").Collection("ratings").Drop(context.TODO())
-
-	// begin insert docs
-	coll := client.Database("tea").Collection("ratings")
+	// begin insertDocs
+	coll := client.Database("db").Collection("books")
 	docs := []interface{}{
-		bson.D{{"type", "Masala"}, {"rating", 10}},
-		bson.D{{"type", "Earl Grey"}, {"rating", 5}},
+		Book{Title: "My Brilliant Friend", Author: "Elena Ferrante", Length: 331},
+		Book{Title: "Lucy", Author: "Jamaica Kincaid", Length: 103},
 	}
 
 	result, err := coll.InsertMany(context.TODO(), docs)
+	//end insertDocs
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
-	// end insert docs
 
-	fmt.Println("InsertOneModel:")
+	fmt.Println("\nInsertOneModel:\n")
 	{
 		// begin bulk insert model
 		models := []mongo.WriteModel{
-			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Oolong"}, {"rating", 9}}),
-			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Assam"}, {"rating", 6}}),
+			mongo.NewInsertOneModel().SetDocument(Book{Title: "Beloved", Author: "Toni Morrison", Length: 324}),
+			mongo.NewInsertOneModel().SetDocument(Book{Title: "Outline", Author: "Rachel Cusk", Length: 258}),
 		}
 		// end bulk insert model
 
@@ -60,7 +67,7 @@ func main() {
 		fmt.Printf("Number of documents inserted: %d\n", results.InsertedCount)
 	}
 
-	fmt.Println("Documents After Insert:")
+	fmt.Println("\nDocuments After Insert:\n")
 	{
 		cursor, err := coll.Find(context.TODO(), bson.D{})
 		if err != nil {
@@ -68,24 +75,25 @@ func main() {
 		}
 		defer cursor.Close(context.TODO())
 
-		var results []bson.D
+		var results []Book
 		if err = cursor.All(context.TODO(), &results); err != nil {
 			panic(err)
 		}
 		for _, result := range results {
-			fmt.Println(result)
+			res, _ := bson.MarshalExtJSON(result, false, false)
+			fmt.Println(string(res))
 		}
 	}
 
-	fmt.Println("ReplaceOneModel:")
+	fmt.Println("\nReplaceOneModel:\n")
 	{
 		// begin bulk replace model
 		models := []mongo.WriteModel{
-			mongo.NewReplaceOneModel().SetFilter(bson.D{{"type", "Earl Grey"}}).
-				SetReplacement(bson.D{{"type", "Matcha"}, {"rating", 8}}),
+			mongo.NewReplaceOneModel().SetFilter(bson.D{{"title", "Lucy"}}).
+				SetReplacement(Book{Title: "On Beauty", Author: "Zadie Smith", Length: 473}),
 		}
 		// end bulk replace model
-		
+
 		results, err := coll.BulkWrite(context.TODO(), models)
 		if err != nil {
 			panic(err)
@@ -94,7 +102,7 @@ func main() {
 		fmt.Printf("Number of documents replaced: %d\n", results.ModifiedCount)
 	}
 
-	fmt.Println("Documents After Replace:")
+	fmt.Println("\nDocuments After Replace:\n")
 	{
 		cursor, err := coll.Find(context.TODO(), bson.D{})
 		if err != nil {
@@ -102,24 +110,25 @@ func main() {
 		}
 		defer cursor.Close(context.TODO())
 
-		var results []bson.D
+		var results []Book
 		if err = cursor.All(context.TODO(), &results); err != nil {
 			panic(err)
 		}
 		for _, result := range results {
-			fmt.Println(result)
+			res, _ := bson.MarshalExtJSON(result, false, false)
+			fmt.Println(string(res))
 		}
 	}
-	
-	fmt.Println("UpdateOneModel:")
+
+	fmt.Println("\nUpdateOneModel:\n")
 	{
 		// begin bulk update model
 		models := []mongo.WriteModel{
-			mongo.NewUpdateOneModel().SetFilter(bson.D{{"type", "Masala"}}).
-				SetUpdate(bson.D{{"$inc", bson.D{{"rating", -2}}}}),
+			mongo.NewUpdateOneModel().SetFilter(bson.D{{"author", "Elena Ferrante"}}).
+				SetUpdate(bson.D{{"$inc", bson.D{{"length", -15}}}}),
 		}
 		// end bulk update model
-		
+
 		results, err := coll.BulkWrite(context.TODO(), models)
 		if err != nil {
 			panic(err)
@@ -128,7 +137,7 @@ func main() {
 		fmt.Printf("Number of documents updated: %d\n", results.ModifiedCount)
 	}
 
-	fmt.Println("Documents After Update:")
+	fmt.Println("\nDocuments After Update:\n")
 	{
 		cursor, err := coll.Find(context.TODO(), bson.D{})
 		if err != nil {
@@ -136,23 +145,24 @@ func main() {
 		}
 		defer cursor.Close(context.TODO())
 
-		var results []bson.D
+		var results []Book
 		if err = cursor.All(context.TODO(), &results); err != nil {
 			panic(err)
 		}
 		for _, result := range results {
-			fmt.Println(result)
+			res, _ := bson.MarshalExtJSON(result, false, false)
+			fmt.Println(string(res))
 		}
 	}
 
-	fmt.Println("DeleteManyModel:")
+	fmt.Println("\nDeleteManyModel:\n")
 	{
 		// begin bulk delete model
 		models := []mongo.WriteModel{
-			mongo.NewDeleteManyModel().SetFilter(bson.D{{"rating", bson.D{{"$gt", 7}}}}),
+			mongo.NewDeleteManyModel().SetFilter(bson.D{{"length", bson.D{{"$gt", 400}}}}),
 		}
 		// end bulk delete model
-		
+
 		results, err := coll.BulkWrite(context.TODO(), models)
 		if err != nil {
 			panic(err)
@@ -161,7 +171,7 @@ func main() {
 		fmt.Printf("Number of documents deleted: %d\n", results.DeletedCount)
 	}
 
-	fmt.Println("Documents After Delete:")
+	fmt.Println("\nDocuments After Delete:\n")
 	{
 		cursor, err := coll.Find(context.TODO(), bson.D{})
 		if err != nil {
@@ -169,44 +179,44 @@ func main() {
 		}
 		defer cursor.Close(context.TODO())
 
-		var results []bson.D
+		var results []Book
 		if err = cursor.All(context.TODO(), &results); err != nil {
 			panic(err)
 		}
 		for _, result := range results {
-			fmt.Println(result)
+			res, _ := bson.MarshalExtJSON(result, false, false)
+			fmt.Println(string(res))
 		}
 	}
 
 	{
-		client.Database("tea").Collection("ratings").Drop(context.TODO())
+		client.Database("db").Collection("books").Drop(context.TODO())
 
-		// begin insert docs
-		coll := client.Database("tea").Collection("ratings")
+		coll := client.Database("db").Collection("books")
 		docs := []interface{}{
-			bson.D{{"type", "Masala"}, {"rating", 10}},
-			bson.D{{"type", "Earl Grey"}, {"rating", 5}},
+			Book{Title: "My Brilliant Friend", Author: "Elena Ferrante", Length: 331},
+			Book{Title: "Lucy", Author: "Jamaica Kincaid", Length: 103},
 		}
 
 		result, err := coll.InsertMany(context.TODO(), docs)
+
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
-		// end insert docs
+		fmt.Printf("\n[Multiple Operations Example]\nNumber of documents inserted: %d\n", len(result.InsertedIDs))
 	}
 
-	fmt.Println("BulkOperation Example:")
+	fmt.Println("\nBulkOperation Example:\n")
 	{
 		// begin unordered
 		models := []mongo.WriteModel{
-			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Oolong"}, {"rating", 9}}),
-			mongo.NewInsertOneModel().SetDocument(bson.D{{"type", "Assam"}, {"rating", 6}}),
-			mongo.NewReplaceOneModel().SetFilter(bson.D{{"type", "Earl Grey"}}).
-				SetReplacement(bson.D{{"type", "Matcha"}, {"rating", 4}}),
-			mongo.NewUpdateManyModel().SetFilter(bson.D{{"rating", bson.D{{"$lt", 7}}}}).
-				SetUpdate(bson.D{{"$inc", bson.D{{"rating", 3}}}}),
-			mongo.NewDeleteManyModel().SetFilter(bson.D{{"rating", 9}}),
+			mongo.NewInsertOneModel().SetDocument(Book{Title: "Middlemarch", Author: "George Eliot", Length: 904}),
+			mongo.NewInsertOneModel().SetDocument(Book{Title: "Pale Fire", Author: "Vladimir Nabokov", Length: 246}),
+			mongo.NewReplaceOneModel().SetFilter(bson.D{{"title", "My Brilliant Friend"}}).
+				SetReplacement(Book{Title: "Atonement", Author: "Ian McEwan", Length: 351}),
+			mongo.NewUpdateManyModel().SetFilter(bson.D{{"length", bson.D{{"$lt", 200}}}}).
+				SetUpdate(bson.D{{"$inc", bson.D{{"length", 10}}}}),
+			mongo.NewDeleteManyModel().SetFilter(bson.D{{"author", bson.D{{"$regex", "Jam"}}}}),
 		}
 		opts := options.BulkWrite().SetOrdered(false)
 
@@ -214,14 +224,14 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		
+
 		fmt.Printf("Number of documents inserted: %d\n", results.InsertedCount)
 		fmt.Printf("Number of documents replaced or updated: %d\n", results.ModifiedCount)
 		fmt.Printf("Number of documents deleted: %d\n", results.DeletedCount)
 		// end unordered
 	}
 
-	fmt.Println("Documents After Bulk Operation:")
+	fmt.Println("\nDocuments After Bulk Operation:\n")
 	{
 		cursor, err := coll.Find(context.TODO(), bson.D{})
 		if err != nil {
@@ -229,12 +239,13 @@ func main() {
 		}
 		defer cursor.Close(context.TODO())
 
-		var results []bson.D
+		var results []Book
 		if err = cursor.All(context.TODO(), &results); err != nil {
 			panic(err)
 		}
 		for _, result := range results {
-			fmt.Println(result)
+			res, _ := bson.MarshalExtJSON(result, false, false)
+			fmt.Println(string(res))
 		}
 	}
 }

--- a/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
@@ -159,7 +159,7 @@ func main() {
 	{
 		// begin bulk delete model
 		models := []mongo.WriteModel{
-			mongo.NewDeleteManyModel().SetFilter(bson.D{{"length", bson.D{{"$gt", 400}}}}),
+			mongo.NewDeleteManyModel().SetFilter(bson.D{{"length", bson.D{{"$gt", 300}}}}),
 		}
 		// end bulk delete model
 

--- a/source/includes/fundamentals/code-snippets/CRUD/delete.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/delete.go
@@ -11,6 +11,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// start-book-struct
+type Book struct {
+	Title  string
+	Author string
+	Length int32
+}
+
+// end-book-struct
+
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
@@ -28,28 +37,28 @@ func main() {
 		}
 	}()
 
-	client.Database("tea").Collection("ratings").Drop(context.TODO())
+	client.Database("db").Collection("books").Drop(context.TODO())
 
 	// begin insertDocs
-	coll := client.Database("tea").Collection("ratings")
+	coll := client.Database("db").Collection("books")
 	docs := []interface{}{
-		bson.D{{"type", "Masala"}, {"rating", 10}},
-		bson.D{{"type", "Earl Grey"}, {"rating", 7}},
-		bson.D{{"type", "Oolong"}, {"rating", 10}},
-		bson.D{{"type", "Assam"}, {"rating", 7}},
+		Book{Title: "Atonement", Author: "Ian McEwan", Length: 351},
+		Book{Title: "My Brilliant Friend", Author: "Elena Ferrante", Length: 331},
+		Book{Title: "Lucy", Author: "Jamaica Kincaid", Length: 103},
+		Book{Title: "Outline", Author: "Rachel Cusk", Length: 258},
 	}
 
 	result, err := coll.InsertMany(context.TODO(), docs)
+	//end insertDocs
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Number of documents inserted: %d\n", len(result.InsertedIDs))
-	// end insertDocs
 
-	fmt.Println("Delete Many:")
+	fmt.Println("\nDelete Many:\n")
 	{
 		// begin deleteMany
-		filter := bson.D{{"rating", bson.D{{"$gt", 8}}}}
+		filter := bson.D{{"length", bson.D{{"$gt", 300}}}}
 		opts := options.Delete().SetHint(bson.D{{"_id", 1}})
 
 		result, err := coll.DeleteMany(context.TODO(), filter, opts)

--- a/source/includes/fundamentals/code-snippets/CRUD/insertOptions.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/insertOptions.go
@@ -6,6 +6,14 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// start-book-struct
+type Book struct {
+	Title  string
+	Author string
+}
+
+// end-book-struct
+
 func insertManyOpts() {
 	// begin insertManyOpts
 	opts := options.InsertMany().SetBypassDocumentValidation(true).SetOrdered(false)


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-26447
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-26447-struct-write-ops/fundamentals/crud/write-operations/#std-label-golang-crud-write-operations

**Pages changed:**
1. bulk operations
2. insert a document
3. delete a document
4. update arrays
5. insert or update

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
