### PR TITLE
[v1.10] change Go value to Go type + backport file (#231)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,12 @@
+{
+  // Required
+  "repoOwner": "mongodb",
+  "repoName": "docs-golang",
+
+  // the branches available to backport to
+  "targetBranchChoices": ["master", "v1.11", "v1.10", "v1.9", "v1.8", "v1.7"],
+
+  // Optional: automatically merge backport PR
+  "autoMerge": true,
+  "autoMergeMethod": "squash"
+}

--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 In this guide, you can learn about how the Go Driver handles conversions
-between BSON and Go values. The process of converting a Go value to
+between BSON and Go types. The process of converting a Go type to
 BSON is called **marshalling**, while the reverse process is called **unmarshalling**.
 
 You should read this guide if you want to learn more about how the Go Driver
@@ -295,7 +295,7 @@ user-defined struct by using methods from the ``bson`` package:
 .. note::
 
    You can use the ``Raw`` type to retrieve elements from a BSON
-   document byte slice without unmarshalling it to a Go value. This can
+   document byte slice without unmarshalling it to a Go type. This can
    be useful if you need to look up individual elements without
    unmarshalling the entire BSON document.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -227,11 +227,11 @@ New features of the 1.3 Go driver release include:
 What's New in 1.2
 -----------------
 
-New features of the 1.2 Go driver release include: 
+New features of the 1.2 Go driver release include:
 
 - Support for {+csfle-short+}.
 
-- ``bson.MarshalValue`` function, which marshals Go values to BSON.
+- ``bson.MarshalValue`` function, which marshals Go types to BSON.
 
 - ``StringCodec``, which allows non-string fields to be decoded into a 
   String field in a struct.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.10`:
 - [change Go value to Go type + backport file (#231)](https://github.com/mongodb/docs-golang/pull/231)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)