### PR TITLE
[v1.7] DOCSP-27258 countDocuments collScan note (#245)

### DIFF
--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -51,12 +51,27 @@ Accurate Count
 --------------
 
 To count the number of documents that match your query filter, use the
-``CountDocuments()`` method.
+``CountDocuments()`` method. If you pass an empty query filter, this method
+returns the total number of documents in the collection.
 
 .. tip::
 
-   If you pass an empty query filter, this method returns the total
-   number of documents in the collection.
+   When you use ``CountDocuments()`` to return the total number of documents in a
+   collection, MongoDB performs a collection scan. You can avoid a collection scan and
+   improve the performance of this method by using a :manual:`hint
+   </reference/method/cursor.hint>` to take advantage of the built-in index on
+   the ``_id`` field. Use this technique only when calling ``CountDocuments()``
+   with an empty query parameter.
+
+   .. code-block:: go
+      :emphasize-lines: 1, 3
+
+      opts := options.Count().SetHint("_id_")
+
+      count, err := coll.CountDocuments(context.TODO(), bson.D{}, opts)
+      if err != nil {
+   	   panic(err)
+      }
 
 Modify Behavior
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.7`:
 - [DOCSP-27258 countDocuments collScan note (#245)](https://github.com/mongodb/docs-golang/pull/245)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)