### PR TITLE
DOCSP-27577: refer to compound operations correctly

### DIFF
--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 In this guide, you can learn how to specify which fields to return in a
-document from read operations.
+document.
 
 Sample Data
 ~~~~~~~~~~~
@@ -58,7 +58,7 @@ corresponding field or ``0`` to exclude it. If you are using an aggregation fram
 you can also specify a projection to include newly computed fields.
 
 You can specify a projection by passing a projection document to the ``SetProjection()``
-method. The following read operations take an options object as a parameter:
+method. The following operations take an options object as a parameter:
 
 - ``Find()``
 - ``FindOne()``
@@ -68,7 +68,7 @@ method. The following read operations take an options object as a parameter:
 
 .. tip::
 
-   If you don't specify a projection, the read operation returns all
+   If you don't specify a projection, the operation returns all
    the fields in matched documents.
 
 Exclude a Field

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 In this guide, you can learn how to specify the order of your results
-from read operations.
+from an operation.
 
 Sample Data
 ~~~~~~~~~~~
@@ -52,7 +52,7 @@ To specify the order of your results, pass an interface specifying the
 sort fields and direction to the ``SetSort()`` method of a read
 operation's options.
 
-The following read operations take options as a parameter:
+The following operations take options as a parameter:
 
 - ``Find()``
 - ``FindOne()``

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -49,8 +49,7 @@ Sort Direction
 --------------
 
 To specify the order of your results, pass an interface specifying the
-sort fields and direction to the ``SetSort()`` method of a read
-operation's options.
+sort fields and direction to the ``SetSort()`` method of an operation's options.
 
 The following operations take options as a parameter:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-27577
Staging - [Sort](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-27577-compound-method-lang/fundamentals/crud/read-operations/sort/) | [Project](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-27577-compound-method-lang/fundamentals/crud/read-operations/project/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [n/a] Did you run a spell-check?
- [n/a] Did you run a grammar-check?
- [n/a] Are all the links working?
