### PR TITLE
DOCSP-29485: remove release notes link from nav, move link to WN

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -17,7 +17,6 @@
    /issues-and-help
    /compatibility
    /whats-new
-   Release Notes <https://github.com/mongodb/mongo-go-driver/releases>
    View the Source <https://github.com/mongodb/mongo-go-driver>
 
 Introduction
@@ -58,12 +57,12 @@ For detailed information about types and methods in the MongoDB
 Go driver, see the `{+driver-long+} API documentation
 <{+api+}/mongo>`__.
 
-.. FAQ
-.. ---
+FAQ
+---
 
-.. For answers to commonly asked questions about the MongoDB
-.. Go Driver, see :ref:`golang-faq`
-.. section.
+For answers to commonly asked questions about the MongoDB
+Go Driver, see :ref:`golang-faq`
+section.
 
 Issues & Help
 -------------
@@ -77,11 +76,11 @@ Compatibility
 For the compatibility charts that show the recommended Go Driver version
 for each MongoDB Server version, see :ref:`golang-compatibility`.
 
-.. What's New
-.. ----------
+What's New
+----------
 
-.. For a list of new features and changes in each version, see the
-.. :ref:`whats-new` section.
+For a list of new features and changes in each version, see the
+:ref:`golang-whats-new` section.
 
 Learn
 ------

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -12,6 +12,13 @@ What's New
    :depth: 1
    :class: singlecol
 
+.. tip:: Release Notes
+   
+   To learn more about changes and updates between versions, you can
+   read the `release notes
+   <https://github.com/mongodb/mongo-go-driver/releases>`__ published
+   in the driver source code.
+
 Learn what's new in:
 
 * :ref:`Version 1.11 <version-1.11>`

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -16,8 +16,7 @@ What's New
    
    To learn more about changes and updates between versions, you can
    read the `release notes
-   <https://github.com/mongodb/mongo-go-driver/releases>`__ published
-   in the driver source code.
+   <https://github.com/mongodb/mongo-go-driver/tags>`__ published with the driver source code.
 
 Learn what's new in:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-29485
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-29485-remove-releasenotes-item/whats-new/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
