### PR TITLE
DOCSP-29541: newclient and connect deprecation notice

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -34,7 +34,6 @@ Learn what's new in:
 * :ref:`Version 1.1 <version-1.1>`
 * :ref:`Version 1.0 <version-1.0>`
 
-.. _version-1.12.0:
 .. _version-1.12:
 
 What's New in 1.12
@@ -43,7 +42,7 @@ What's New in 1.12
 .. important:: Deprecation Notice
 
    - The ``mongo.NewClient()`` and ``client.Connect()`` methods are
-     deprecated because you can create a client and connect in one call
+     deprecated. You can create a client and connect in one call
      by using the ``mongo.Connect()`` method.
 
 .. _version-1.11.0:

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -20,6 +20,7 @@ What's New
 
 Learn what's new in:
 
+* :ref:`Version 1.12 <version-1.12>`
 * :ref:`Version 1.11 <version-1.11>`
 * :ref:`Version 1.10 <version-1.10>`
 * :ref:`Version 1.9 <version-1.9>`
@@ -33,11 +34,23 @@ Learn what's new in:
 * :ref:`Version 1.1 <version-1.1>`
 * :ref:`Version 1.0 <version-1.0>`
 
+.. _version-1.12.0:
+.. _version-1.12:
+
+What's New in 1.12
+------------------
+
+.. important:: Deprecation Notice
+
+   - The ``mongo.NewClient()`` and ``client.Connect()`` methods are
+     deprecated because you can create a client and connect in one call
+     by using the ``mongo.Connect()`` method.
+
 .. _version-1.11.0:
 .. _version-1.11:
 
 What's New in 1.11
---------------------
+------------------
 
 .. important:: Upgrade to Version 1.11.3 or Higher
 
@@ -90,7 +103,7 @@ New features of the 1.11 Go driver release include:
 .. _version-1.10:
 
 What's New in 1.10
---------------------
+------------------
 
 .. important:: Upgrade to Version 1.10.1 or Higher 
 
@@ -141,7 +154,7 @@ New features of the 1.10 Go driver release include:
 .. _version-1.9:
 
 What's New in 1.9
--------------------
+-----------------
 
 New features of the 1.9 Go driver release include: 
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - [DOCSP-29541](https://jira.mongodb.org/browse/DOCSP-29541)
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-29541-newclient-deprecated/whats-new/#what-s-new-in-1.12

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
