### PR TITLE
DOCSP-30083 : Backport fix geospatial typo (#264 to v1.11)

### DIFF
--- a/source/fundamentals/geo.txt
+++ b/source/fundamentals/geo.txt
@@ -168,9 +168,9 @@ For more information on legacy coordinate pairs, see the
 Geospatial Indexes
 ------------------
 
-To enable querying for geosptial data, you must first create a supporting
-index. The following index types that enable geospatial queries:
-
+To enable querying on geospatial data, you must create an index that
+corresponds to the data format. The following index types enable geospatial
+queries:
 
 - ``2dsphere`` for GeoJSON data
 - ``2d`` for legacy coordinate pairs


### PR DESCRIPTION
Backport #264 to v1.11
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?

https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/v1.11/fundamentals/geo/#geospatial-indexes
