### PR TITLE
DOCSP-30082: Replace doc directives

### DIFF
--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -4,8 +4,6 @@
 Collations
 ==========
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -249,7 +249,7 @@ guides:
 - :ref:`golang-skip`
 - :ref:`golang-limit`
 - :ref:`golang-aggregation` 
-- :ref: `golang-collations`
+- :ref: `Collations <golang-collations>`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -249,8 +249,7 @@ guides:
 - :ref:`golang-skip`
 - :ref:`golang-limit`
 - :ref:`golang-aggregation` 
-
-.. - :doc:`Collations </fundamentals/collations>`
+- :ref: `golang-collations`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -249,7 +249,7 @@ guides:
 - :ref:`golang-skip`
 - :ref:`golang-limit`
 - :ref:`golang-aggregation` 
-- :ref: `Collations <golang-collations>`
+- :ref:`Collations <golang-collations>`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -4,8 +4,6 @@
 Count Documents
 ===============
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -249,7 +249,7 @@ guides:
 - :ref:`golang-skip`
 - :ref:`golang-limit`
 - :ref:`golang-aggregation` 
-- :ref:`Collations <golang-collations>`
+- :ref:`golang-collations`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/query-document.txt
+++ b/source/fundamentals/crud/read-operations/query-document.txt
@@ -4,8 +4,6 @@
 Specify a Query
 ===============
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/read-operations/query-document.txt
+++ b/source/fundamentals/crud/read-operations/query-document.txt
@@ -445,6 +445,8 @@ Additional Information
 
 For information on specifying a geospatial query, see the guide on
 :ref:`Geospatial Data <golang-geo>`.
+
+API Documentation
 ~~~~~~~~~~~~~~~~~
 
 To learn more about any of the methods or types used in this

--- a/source/fundamentals/crud/read-operations/query-document.txt
+++ b/source/fundamentals/crud/read-operations/query-document.txt
@@ -443,10 +443,8 @@ Query Operators </reference/operator/query-bitwise/>` page.
 Additional Information
 ----------------------
 
-.. For information on specifying a geospatial query, see the guide on
-.. :doc:`Geospatial Data </fundamentals/crud/read-operations/geospatial>`.
-
-API Documentation
+For information on specifying a geospatial query, see the guide on
+:ref:`Geospatial Data <golang-geo>`.
 ~~~~~~~~~~~~~~~~~
 
 To learn more about any of the methods or types used in this

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -4,8 +4,6 @@
 Search Text
 ===========
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -387,8 +387,7 @@ guides:
 - :manual:`$text </reference/operator/query/text/>`
 - :manual:`$meta </reference/operator/aggregation/meta/>`
 - :ref:`golang-aggregation`
-
-.. - :doc:`Indexes </fundamentals/crud/indexes>`
+- :ref:`golang-indexes`
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -4,8 +4,6 @@
 Change a Document
 =================
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -126,8 +126,8 @@ the method selects and updates the first matched document. If no
 documents match the query filter, the update operation makes no
 changes. 
 
-.. See our :doc:`upsert guide </fundamentals/crud/write-operations/upsert>`
-.. to learn how to insert a new document if no documents match the query filter.
+See our :ref:`upsert guide <golang-upsert-guide>`
+to learn how to insert a new document if no documents match the query filter.
 
 Example
 ```````

--- a/source/includes/fundamentals-sections.rst
+++ b/source/includes/fundamentals-sections.rst
@@ -18,4 +18,3 @@ Fundamentals section:
 - :ref:`Encrypt Fields <golang-fle>`
 - :ref:`Work with Geospatial Data <golang-geo>`
 
-.. - :doc:`Record Events in the Driver </fundamentals/logging>`


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-30082>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-30082-replace-doc-directives/fundamentals/crud/read-operations/count/>

replaced :doc: with :ref: in 5 locations/ turned unimplemented :doc: comments into updated, implemented documentation.

 
## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
