### PR TITLE
DOCSP-31832 - 1.11.8 retraction

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -114,7 +114,7 @@ Additional Changes
 What's New in 1.11
 ------------------
 
-.. important:: Upgrade to Version 1.11.9 or Higher
+.. important:: Upgrade to Version 1.11.9 or Later
 
    Versions 1.11.0 through 1.11.2 of the driver have been retracted because
    of a bug that could cause undefined behavior when reading the ``Raw`` field
@@ -122,9 +122,9 @@ What's New in 1.11
    ``WriteException``.
 
    Version 1.11.8 of the driver has been retracted because 
-   it incorrectly contains minor release changes intended for 1.12.1.
+   it incorrectly contains changes intended for 1.12.1.
    
-   Upgrade to version 1.11.9 or higher if you are using a retracted
+   Upgrade to version 1.11.9 or later if you are using a retracted
    version of the driver.
 
 New features of the 1.11 Go driver release include: 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -114,14 +114,17 @@ Additional Changes
 What's New in 1.11
 ------------------
 
-.. important:: Upgrade to Version 1.11.3 or Higher
+.. important:: Upgrade to Version 1.11.9 or Higher
 
    Versions 1.11.0 through 1.11.2 of the driver have been retracted because
    of a bug that could cause undefined behavior when reading the ``Raw`` field
    on database error types, such as ``CommandError`` and
    ``WriteException``.
+
+   Version 1.11.18 of the driver has been retracted because 
+   it incorrectly contains minor release changes intended for 1.12.1.
    
-   Upgrade to version 1.11.3 or higher if you are using a retracted
+   Upgrade to version 1.11.9 or higher if you are using a retracted
    version of the driver.
 
 New features of the 1.11 Go driver release include: 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -121,7 +121,7 @@ What's New in 1.11
    on database error types, such as ``CommandError`` and
    ``WriteException``.
 
-   Version 1.11.18 of the driver has been retracted because 
+   Version 1.11.8 of the driver has been retracted because 
    it incorrectly contains minor release changes intended for 1.12.1.
    
    Upgrade to version 1.11.9 or higher if you are using a retracted


### PR DESCRIPTION
# Pull Request Info

[Version 1.11.8 has been retracted](https://github.com/mongodb/mongo-go-driver/releases/tag/v1.11.8)

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-31832
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/docsp-31832-version-update/whats-new/#what-s-new-in-1.11

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
