### PR TITLE
DOCSP-32073: Atomic typo and related fixes

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -78,7 +78,7 @@ the ``maxIdleTimeMS`` option, which defaults to ``None`` (no limit).
 The following default configuration for a ``Client`` works for most applications:
 
 .. code-block:: go
-   
+
    client := mongo.Connect("<connection string>")
 
 Create a client once for each process, and reuse it for all
@@ -126,14 +126,14 @@ internally uses the ``bson.Marshal()`` method or when you call
 ``bson.Marshal()`` directly to encode data.
 
 The following code produces a ``WriteNull`` error because the driver
-cannot encode the ``null`` valued ``sortOrder`` variable to BSON during
+cannot encode the ``null`` value of ``sortOrder`` to BSON during
 the ``FindOneAndUpdate()`` operation:
 
 .. code-block:: go
 
    var sortOrder bson.D
    opts := options.FindOneAndUpdate().SetSort(sortOrder)
-   
+
    updateDocument := bson.D{{"$inc", bson.D{{"counter", 1}}}}
    result := coll.FindOneAndUpdate(context.TODO(), bson.D{}, updateDocument, opts)
    if err := result.Err(); err != nil {
@@ -168,12 +168,12 @@ using string type-casting:
       :emphasize-lines: 3
 
       bsonDocument := bson.D{{"hello", "world"}}
-      
+
       jsonBytes, err := bson.MarshalExtJSON(bsonDocument, true, false)
       if err != nil {
           panic(err)
       }
-      
+
       fmt.Println(string(jsonBytes))
 
    .. output::

--- a/source/fundamentals/context.txt
+++ b/source/fundamentals/context.txt
@@ -17,7 +17,7 @@ Overview
 
 The {+driver-long+} uses the `context package
 <https://pkg.go.dev/context>`__ from Go's standard library to allow
-applications to signal timeouts and cancellations for any **blocking method**
+applications to signal timeouts and cancelations for any **blocking method**
 call. A blocking method relies on an external event, such as a network
 input or output, to proceed with its task.
 

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -20,7 +20,7 @@ In this guide, you can learn how to access data with a **cursor**.
 A cursor is a mechanism that allows an application to iterate over
 database results while holding only a subset of them in memory at a
 given time. Read operations that match multiple documents use a cursor
-to return those documents in batches as opposed to all at once.
+to return those documents in batches rather than all at once.
 
 Sample Cursor
 ~~~~~~~~~~~~~

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -18,9 +18,9 @@ Overview
 In this guide, you can learn how to store and retrieve large files in
 MongoDB using the **GridFS** specification. GridFS splits large files
 into chunks and stores each chunk as a separate document. When you query
-GridFS for a file, the driver will reassemble the chunks as needed. The
+GridFS for a file, the driver assembles the chunks as needed. The
 driver implementation of GridFS is an abstraction that manages the operations
-and organization of the file storage. 
+and organization of the file storage.
 
 Use GridFS if the size of your files exceeds the BSON document size limit of
 16 MB. GridFS is also useful for accessing files without loading the entire file
@@ -37,7 +37,7 @@ bucket contains the following collections:
 - The ``chunks`` collection, which stores the binary file chunks.
 - The ``files`` collection, which stores the file metadata.
 
-When you create a new GridFS bucket, the driver creates the preceding 
+When you create a new GridFS bucket, the driver creates the preceding
 collections. The default bucket name ``fs`` prefixes the collection names,
 unless you specify a different bucket name. The driver creates the new GridFS
 bucket during the first write operation.
@@ -98,7 +98,7 @@ call the ``NewBucket()`` method with a database parameter:
    reference to the bucket rather than instantiating a new one.
 
 By default, the new bucket is named ``fs``. To instantiate a bucket with a
-custom name, call the ``SetName()`` method on a ``BucketOptions`` instance as 
+custom name, call the ``SetName()`` method on a ``BucketOptions`` instance as
 follows:
 
 .. code-block:: go
@@ -106,7 +106,7 @@ follows:
    db := client.Database("myDB")
    opts := options.GridFSBucket().SetName("custom name")
    bucket, err := gridfs.NewBucket(db, opts)
-   
+
    if err != nil {
       panic(err)
    }
@@ -122,7 +122,7 @@ You can upload a file into a GridFS bucket in one of the following ways:
 - Use the ``OpenUploadStream()`` method, which writes to an output stream.
 
 For either upload process, you can specify configuration information on an instance
-of ``UploadOptions``. For a full list of ``UploadOptions`` fields, visit the 
+of ``UploadOptions``. For a full list of ``UploadOptions`` fields, visit the
 `API documentation <{+api+}/mongo/options#UploadOptions>`__.
 
 Upload with an Input Stream
@@ -159,12 +159,8 @@ content to a GridFS bucket. It uses an ``opts`` parameter to set file metadata:
       :language: none
       :visible: false
 
-      New file uploaded with ID 62e005408bc04f3816b8bcd2
+      New file uploaded with ID 62e00...
 
-.. note::
-
-   The driver uniquely generates each object ID number. The ID number outputted
-   will resemble the sample output but varies with each file and user.
 
 Upload with an Output Stream
 ````````````````````````````
@@ -208,7 +204,7 @@ only certain file documents.
 
 .. note::
 
-   The ``Find()`` method requires a query filter as a parameter. To match all 
+   The ``Find()`` method requires a query filter as a parameter. To match all
    documents in the ``files`` collection, pass an empty query filter to ``Find()``.
 
 The following example retrieves the file name and length of documents in the
@@ -292,7 +288,7 @@ Rename Files
 
 You can update the name of a GridFS file in your bucket by using the ``Rename()``
 method. Pass a file ID value and a new ``filename`` value as arguments to
-``Rename()``. 
+``Rename()``.
 
 The following example renames a file to ``"mongodbTutorial.zip"``:
 
@@ -309,7 +305,7 @@ Delete Files
 ~~~~~~~~~~~~
 
 You can remove a file from your GridFS bucket by using the ``Delete()`` method.
-Pass a file ID value as an argument to ``Delete()``. 
+Pass a file ID value as an argument to ``Delete()``.
 
 The following example deletes a file:
 

--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -44,7 +44,7 @@ to the ``ServerClosed`` event by instantiating a
            eventArray = append(eventArray, e)
        },
    }
-   clientOpts := options.Client().ApplyURI(uri).SetServerMonitor(svrMonitor)
+   clientOpts := options.Client().ApplyURI(uri).SetServerMonitor(srvMonitor)
    client, err := mongo.Connect(context.Background(), clientOpts)
 
 Event Descriptions

--- a/source/includes/fundamentals/automatic-db-coll-creation.rst
+++ b/source/includes/fundamentals/automatic-db-coll-creation.rst
@@ -1,4 +1,4 @@
-.. tip:: Non-existent Databases and Collections
+.. tip:: Nonexistent Databases and Collections
 
    If the necessary database and collection don't exist when
    you perform a write operation, the server implicitly creates

--- a/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/bulkOps.go
@@ -23,7 +23,7 @@ type Book struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/compoundOperations.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/compoundOperations.go
@@ -22,7 +22,7 @@ type Course struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/countAndEstimate.go
@@ -22,7 +22,7 @@ type Tea struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/cursor.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/cursor.go
@@ -21,7 +21,7 @@ type MyStruct struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/delete.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/delete.go
@@ -23,7 +23,7 @@ type Book struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/distinctValues.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/distinctValues.go
@@ -23,7 +23,7 @@ type Course struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/limit.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/limit.go
@@ -23,7 +23,7 @@ type Course struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/projection.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/projection.go
@@ -23,7 +23,7 @@ type Course struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/query.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/query.go
@@ -24,7 +24,7 @@ type Tea struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/retrieve.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/retrieve.go
@@ -25,7 +25,7 @@ type Review struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("DRIVER_REF_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/runCommand.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/runCommand.go
@@ -16,7 +16,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/skip.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/skip.go
@@ -23,7 +23,7 @@ type Course struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/sort.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/sort.go
@@ -23,7 +23,7 @@ type Course struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/textSearch.go
@@ -23,7 +23,7 @@ type Dish struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/updateArray.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/updateArray.go
@@ -23,7 +23,7 @@ type Drink struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/CRUD/upsert.go
+++ b/source/includes/fundamentals/code-snippets/CRUD/upsert.go
@@ -23,7 +23,7 @@ type Plant struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/aggregation.go
+++ b/source/includes/fundamentals/code-snippets/aggregation.go
@@ -25,7 +25,7 @@ type Tea struct {
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/logging.go
+++ b/source/includes/fundamentals/code-snippets/logging.go
@@ -23,7 +23,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 	//standardLogging(uri)
 	//customLogging(uri)

--- a/source/includes/fundamentals/code-snippets/timeSeries.go
+++ b/source/includes/fundamentals/code-snippets/timeSeries.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://docs.mongodb.com/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/fundamentals/code-snippets/transaction.go
+++ b/source/includes/fundamentals/code-snippets/transaction.go
@@ -16,7 +16,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/")
 	}
 
 	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(uri))

--- a/source/includes/quick-start/main.go
+++ b/source/includes/quick-start/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	uri := os.Getenv("MONGODB_URI")
 	if uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
 	if err != nil {

--- a/source/includes/usage-examples/code-snippets/bulk.go
+++ b/source/includes/usage-examples/code-snippets/bulk.go
@@ -31,7 +31,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/command.go
+++ b/source/includes/usage-examples/code-snippets/command.go
@@ -20,7 +20,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/count.go
+++ b/source/includes/usage-examples/code-snippets/count.go
@@ -19,7 +19,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/deleteMany.go
+++ b/source/includes/usage-examples/code-snippets/deleteMany.go
@@ -19,7 +19,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/deleteOne.go
+++ b/source/includes/usage-examples/code-snippets/deleteOne.go
@@ -19,7 +19,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/distinct.go
+++ b/source/includes/usage-examples/code-snippets/distinct.go
@@ -19,7 +19,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/find.go
+++ b/source/includes/usage-examples/code-snippets/find.go
@@ -34,7 +34,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/findOne.go
+++ b/source/includes/usage-examples/code-snippets/findOne.go
@@ -34,7 +34,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/insertMany.go
+++ b/source/includes/usage-examples/code-snippets/insertMany.go
@@ -30,7 +30,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/insertOne.go
+++ b/source/includes/usage-examples/code-snippets/insertOne.go
@@ -30,7 +30,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/replace.go
+++ b/source/includes/usage-examples/code-snippets/replace.go
@@ -31,7 +31,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/struct-tag.go
+++ b/source/includes/usage-examples/code-snippets/struct-tag.go
@@ -32,7 +32,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/updateMany.go
+++ b/source/includes/usage-examples/code-snippets/updateMany.go
@@ -19,7 +19,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/updateOne.go
+++ b/source/includes/usage-examples/code-snippets/updateOne.go
@@ -20,7 +20,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/includes/usage-examples/code-snippets/watch.go
+++ b/source/includes/usage-examples/code-snippets/watch.go
@@ -20,7 +20,7 @@ func main() {
 
 	var uri string
 	if uri = os.Getenv("MONGODB_URI"); uri == "" {
-		log.Fatal("You must set your 'MONGODB_URI' environmental variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
+		log.Fatal("You must set your 'MONGODB_URI' environment variable. See\n\t https://www.mongodb.com/docs/drivers/go/current/usage-examples/#environment-variable")
 	}
 
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -65,7 +65,7 @@ in the base directory of your project. Use the following sample
 code to run a query on your sample dataset in MongoDB Atlas.
 
 Set the value of the ``uri`` variable with your MongoDB Atlas connection
-string, or create an environmental variable with the name ``MONGODB_URI``
+string, or create an environment variable with the name ``MONGODB_URI``
 with your Atlas connection string.
 
 .. code-block:: bash


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-32073>
Staging - 

[FAQ - valued -> value of ](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-32073-atomic-typo-fixes/faq/)

[Context - cancellations -> cancelations](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-32073-atomic-typo-fixes/fundamentals/context/)

[Cursor - opposed to -> rather than](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-32073-atomic-typo-fixes/fundamentals/crud/read-operations/cursor/)

[GridFS - reassemble -> assemble](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-32073-atomic-typo-fixes/fundamentals/gridfs/)

[Monitoring - svrMonitor -> srvMonitor](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-32073-atomic-typo-fixes/fundamentals/monitoring/)

[Quick Start - environmental -> environment](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-32073-atomic-typo-fixes/quick-start/)

[One instance of included file - non-existent -> nonexistent](https://docs-mongodbcom-staging.corp.mongodb.com/golang/docsworker-xlarge/DOCSP-32073-atomic-typo-fixes/fundamentals/crud/write-operations/embedded-arrays/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
