### PR TITLE
fix version redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,6 @@
 define: prefix docs/drivers/go
 define: base https://www.mongodb.com/${prefix}
-define: versions 1.7 1.8 1.9 1.10 1.11 1.12 master
+define: versions v1.7 v1.8 v1.9 v1.10 v1.11 v1.12 master
 
 symlink: current -> master
 
@@ -10,5 +10,5 @@ raw: ${prefix}/stable -> ${base}/current/
 [*-master]: ${prefix}/${version}/fundamentals/crud/read-operations/watch/ -> ${base}/${version}/fundamentals/crud/read-operations/changestream/
 [*-master]: ${prefix}/${version}/usage-examples/watch/ -> ${base}/${version}/usage-examples/changestream/
 [*-master]: ${prefix}/${version}/fundamentals/crud/run-command/ -> ${base}/${version}/fundamentals/run-command/
-[*-1.11]: ${prefix}/${version}/fundamentals/logging/ -> ${base}/${version}/
+[*-v1.11]: ${prefix}/${version}/fundamentals/logging/ -> ${base}/${version}/
 [*-master]: ${prefix}/${version}/fundamentals/crud/write-operations/change-a-document/ -> ${base}/${version}/fundamentals/crud/write-operations/modify/


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

To observe the current behavior:
1) Visit https://www.mongodb.com/docs/drivers/go/current/fundamentals/logging/
2) Use the version selector to switch to version v1.9. This should redirect to the landing page, but instead produces a 404.

JIRA - None
Staging - None

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
