### PR TITLE
DOCSP-31790 update title to alphabetize legacy product menu

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "golang"
-title = "Go"
+title = "Go Driver"
 toc_landing_pages = [
     "/fundamentals/connection",
     "/fundamentals/crud",


### PR DESCRIPTION
Hello again (again, again) @caitlindavey!

Here's the PR for renaming the Go Driver title field in the snooty.toml files so that DOP can set up the legacy menu to pull from that field. Please backport to older versions if we're good to go.

This changes two elements on the page: the top level on the level nav and the breadcrumb verbiage. It was previously just 'Go'

Here's my [build log ](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=653aded13ede3ec111759102).

Thanks for your review & merge!
Sarah

# Pull Request Info
JIRA - <https://jira.mongodb.org/browse/DOCSP-31790>
Staging - <https://preview-mongodbsarahemlin.gatsbyjs.io/golang/DOCSP-31790/>