### PR TITLE
DOCSP-35287 Fix incorrect BSON option

### DIFF
--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -4,13 +4,18 @@
 Work with BSON
 ==============
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
    :depth: 2
    :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: code examples, serialization 
 
 Overview
 --------

--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -219,7 +219,7 @@ This example performs the following actions:
   
   - Sets the ``UseJSONStructTags`` field to ``true``, which instructs the driver
     to use the ``"json"`` struct tag if a ``"bson"`` struct tag is not specified
-  - Sets the ``OmitZeroStruct`` field to ``true``, which instructs the driver
+  - Sets the ``NilSliceAsEmpty`` field to ``true``, which instructs the driver
     to marshal ``nil`` Go slices as empty BSON arrays
 
 - Passes the ``BSONOptions`` instance to the ``SetBSONOptions()`` helper method to specify
@@ -230,7 +230,7 @@ This example performs the following actions:
 
    bsonOpts := &options.BSONOptions {
        UseJSONStructTags: true,
-       OmitZeroStruct: true,
+       NilSliceAsEmpty: true,
    }
 
    clientOpts := options.Client().


### PR DESCRIPTION
# Pull Request Info

Changing the `OmitZeroStruct` option to `NilSliceAsEmpty` to match with the description of the option in the narrative.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-35287
Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/golang/bson-option-typo/fundamentals/bson/#bson-options

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
