### PR TITLE
DOCSP-35287 Fix incorrect BSON option (#329)

### DIFF
--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -4,13 +4,18 @@
 Work with BSON
 ==============
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
    :depth: 2
    :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: code examples, serialization 
 
 Overview
 --------
@@ -219,7 +224,7 @@ This example performs the following actions:
   
   - Sets the ``UseJSONStructTags`` field to ``true``, which instructs the driver
     to use the ``"json"`` struct tag if a ``"bson"`` struct tag is not specified
-  - Sets the ``OmitZeroStruct`` field to ``true``, which instructs the driver
+  - Sets the ``NilSliceAsEmpty`` field to ``true``, which instructs the driver
     to marshal ``nil`` Go slices as empty BSON arrays
 
 - Passes the ``BSONOptions`` instance to the ``SetBSONOptions()`` helper method to specify
@@ -230,7 +235,7 @@ This example performs the following actions:
 
    bsonOpts := &options.BSONOptions {
        UseJSONStructTags: true,
-       OmitZeroStruct: true,
+       NilSliceAsEmpty: true,
    }
 
    clientOpts := options.Client().


### PR DESCRIPTION
(cherry picked from commit bacbc5f093469027be55536fa7c4a446e3f1f705)

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
