### PR TITLE
DOCSP-35814: renames connid64 type, removes old field in v2

### DIFF
--- a/source/fundamentals/monitoring/command-monitoring.txt
+++ b/source/fundamentals/monitoring/command-monitoring.txt
@@ -86,7 +86,6 @@ CommandStartedEvent
        "RequestID": ...,
        "ConnectionID": "...",
        "ServerConnectionID": ...,
-       "ServerConnectionID64": ...,
        "ServiceID": "..."
    }
 
@@ -104,7 +103,6 @@ CommandSucceededEvent
        "RequestID": 13,
        "ConnectionID": "...",
        "ServerConnectionID": ...,
-       "ServerConnectionID64": ...,
        "ServiceID": null,
        "Reply": "..."
    }
@@ -123,7 +121,6 @@ CommandFailedEvent
        "RequestID": 13,
        "ConnectionID": "...",
        "ServerConnectionID": ...,
-       "ServerConnectionID64": ...,
        "ServiceID": null,
        "Failure": "..."
    }

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -57,10 +57,17 @@ What's New in 2.0
 
 The 2.0 {+driver-short+} release includes the following improvements and fixes:
 
-- Consolidation of the ``ServerConnectionID64`` and ``ServerConnectionID``
-  fields of the ``CommandStartedEvent`` and ``CommandFinishedEvent``
-  structs into the ``ServerConnectionID`` field. This field in all
-  ``PoolEvent`` documents has a value of type ``int64``.
+- Updates to monitoring event documents:
+
+  - Consolidation of the ``ServerConnectionID64`` and ``ServerConnectionID``
+    fields of the ``CommandStartedEvent`` and ``CommandFinishedEvent``
+    structs into the ``ServerConnectionID`` field, which takes a value of
+    type ``int64``.
+    
+  - Changes the type of the ``ConnectionID`` field in ``PoolEvent``
+    structs to ``int64`` from ``uint64``.
+
+  To view samples of all event documents, see the :ref:`golang-monitoring` guides.
 
 .. _version-1.13:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -59,15 +59,14 @@ The 2.0 {+driver-short+} release includes the following improvements and fixes:
 
 - Updates to monitoring event documents:
 
-  - Consolidation of the ``ServerConnectionID64`` and ``ServerConnectionID``
-    fields of the ``CommandStartedEvent`` and ``CommandFinishedEvent``
-    structs into the ``ServerConnectionID`` field, which takes a value of
-    type ``int64``.
+  - The ``CommandStartedEvent`` and ``CommandFinishedEvent`` structs
+    have a single ``ServerConnectionID`` field of type ``int64`` to
+    capture the connection ID.
     
   - Changes the type of the ``ConnectionID`` field in ``PoolEvent``
     structs to ``int64`` from ``uint64``.
 
-  To view samples of all event documents, see the :ref:`golang-monitoring` guides.
+  To view sample event documents, see the :ref:`golang-monitoring` guides.
 
 .. _version-1.13:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -63,8 +63,8 @@ The 2.0 {+driver-short+} release includes the following improvements and fixes:
     have a single ``ServerConnectionID`` field of type ``int64`` to
     capture the connection ID.
     
-  - The ``ConnectionID`` field in the ``PoolEvent``
-    struct take a value of type ``int64`` instead of ``uint64``.
+  - The ``ConnectionID`` field of the ``PoolEvent``
+    struct takes a value of type ``int64`` instead of ``uint64``.
 
   To view sample event documents, see the :ref:`golang-monitoring` guides.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -55,6 +55,13 @@ What's New in 2.0
    :ref:`Connection Example Code <go-connection-example-code>` in the
    Connection Guide.
 
+The 2.0 {+driver-short+} release includes the following improvements and fixes:
+
+- Consolidation of the ``ServerConnectionID64`` and ``ServerConnectionID``
+  fields of the ``CommandStartedEvent`` and ``CommandFinishedEvent``
+  structs into the ``ServerConnectionID`` field. This field in all
+  ``PoolEvent`` documents has a value of type ``int64``.
+
 .. _version-1.13:
 
 What's New in 1.13

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -63,8 +63,8 @@ The 2.0 {+driver-short+} release includes the following improvements and fixes:
     have a single ``ServerConnectionID`` field of type ``int64`` to
     capture the connection ID.
     
-  - Changes the type of the ``ConnectionID`` field in ``PoolEvent``
-    structs to ``int64`` from ``uint64``.
+  - The ``ConnectionID`` field in the ``PoolEvent``
+    struct take a value of type ``int64`` instead of ``uint64``.
 
   To view sample event documents, see the :ref:`golang-monitoring` guides.
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35814>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/golang/DOCSP-35814-serverconnID-field-rm/whats-new/#std-label-version-2.0

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
