### PR TITLE
DOCSP-38345: session converted to struct

### DIFF
--- a/source/fundamentals/transactions.txt
+++ b/source/fundamentals/transactions.txt
@@ -58,7 +58,7 @@ Methods
 -------
 
 After you start a session by using the ``StartSession()`` method, you can modify
-the session state by using the method set provided by the ``Session`` struct. The
+the session state by using the method set provided by the returned ``Session``. The
 following table describes these methods:
 
 .. list-table::
@@ -123,9 +123,9 @@ following table describes these methods:
        | **Parameter**: ``Context``
        | **Return Type**: none
 
-The ``Session`` struct also has methods to retrieve session
-properties and modify mutable session properties. Find more information
-in the :ref:`API documentation <api-docs-transaction>`.
+A ``Session`` also has methods to retrieve session
+properties and modify mutable session properties. View the :ref:`API
+documentation <api-docs-transaction>` to learn more about these methods.
 
 Example
 -------

--- a/source/fundamentals/transactions.txt
+++ b/source/fundamentals/transactions.txt
@@ -58,7 +58,7 @@ Methods
 -------
 
 After you start a session by using the ``StartSession()`` method, you can modify
-the session state by using the method set provided by the ``Session`` interface. The
+the session state by using the method set provided by the ``Session`` struct. The
 following table describes these methods:
 
 .. list-table::
@@ -123,7 +123,7 @@ following table describes these methods:
        | **Parameter**: ``Context``
        | **Return Type**: none
 
-The ``Session`` interface also has methods to retrieve session
+The ``Session`` struct also has methods to retrieve session
 properties and modify mutable session properties. Find more information
 in the :ref:`API documentation <api-docs-transaction>`.
 

--- a/source/includes/fundamentals/code-snippets/transaction.go
+++ b/source/includes/fundamentals/code-snippets/transaction.go
@@ -43,7 +43,7 @@ func main() {
 
 	// Inserts multiple documents into a collection within a transaction,
 	// then commits or ends the transaction
-	result, err := session.WithTransaction(context.TODO(), func(ctx mongo.SessionContext) (interface{}, error) {
+	result, err := session.WithTransaction(context.TODO(), func(ctx context.Context) (interface{}, error) {
 		result, err := coll.InsertMany(ctx, []interface{}{
 			bson.D{{"title", "The Bluest Eye"}, {"author", "Toni Morrison"}},
 			bson.D{{"title", "Sula"}, {"author", "Toni Morrison"}},

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -79,6 +79,9 @@ The 2.0 {+driver-short+} release includes the following improvements and fixes:
 
   To view sample event documents, see the :ref:`golang-monitoring` guides.
 
+- The ``Session`` interface is converted to a struct. See the
+  :ref:`golang-transactions` guide to learn more.
+
 .. _version-1.15:
 
 What's New in 1.15


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-38345>
Staging
- [whats new](https://preview-mongodbrustagir.gatsbyjs.io/golang/DOCSP-38345-session-struct/whats-new/#std-label-version-2.0)
- [txn page](https://preview-mongodbrustagir.gatsbyjs.io/golang/DOCSP-38345-session-struct/fundamentals/transactions/#example)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
