### PR TITLE
DOCSP-41551: dropone() return type

### DIFF
--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -451,6 +451,9 @@ from the ``sample_mflix.movies`` collection:
 
    coll := client.Database("sample_mflix").Collection("movies")
    err := coll.Indexes().DropOne(context.TODO(), "title_1")
+   if err != nil {
+       panic(err)
+   }
 
 Additional Information
 ----------------------

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -444,7 +444,7 @@ You can delete any index from a collection except the default unique index on th
 ``_id`` field. To remove an index, pass the name of your index to the
 ``DropOne()`` method.
 
-The following example removes the index called ``title_1``
+The following example removes an index called ``title_1``
 from the ``sample_mflix.movies`` collection:
 
 .. code-block:: go

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -440,31 +440,17 @@ The following example creates a unique, descending index on the ``theaterId`` fi
 Remove an Index
 ---------------
 
-You can remove any unused index except the default unique index on the
+You can delete any index from a collection except the default unique index on the
 ``_id`` field. To remove an index, pass the name of your index to the
 ``DropOne()`` method.
 
-The following example removes an ascending index on the ``title`` field
-in the ``sample_mflix.movies`` collection:
+The following example removes the index called ``title_1``
+from the ``sample_mflix.movies`` collection:
 
-.. io-code-block::
-   :copyable: true
+.. code-block:: go
 
-   .. input::
-      :language: go
-
-      coll := client.Database("sample_mflix").Collection("movies")
-      res, err := coll.Indexes().DropOne(context.TODO(), "title_1")
-      if err != nil {
-          panic(err)
-      }
-      fmt.Println(res)
-
-   .. output::
-      :language: none
-      :visible: false
-
-      {"nIndexesWas": {"$numberInt":"2"}}
+   coll := client.Database("sample_mflix").Collection("movies")
+   err := coll.Indexes().DropOne(context.TODO(), "title_1")
 
 Additional Information
 ----------------------

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -87,6 +87,11 @@ The 2.0 {+driver-short+} release includes the following improvements and fixes:
 - The ``Distinct()`` method returns a struct that can be decoded into a
   specified type. See the :ref:`golang-retrieve-distinct` guide to learn more.
 
+- The ``IndexView.DropOne()`` method returns only an error, if present. In
+  previous versions, this method returns the server response, which
+  contains the number of dropped indexes. See the
+  :ref:`golang-remove-index` section of the Indexes guide to learn more.
+
 .. _version-1.16:
 
 What's New in 1.16

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -88,8 +88,8 @@ The 2.0 {+driver-short+} release includes the following improvements and fixes:
   specified type. See the :ref:`golang-retrieve-distinct` guide to learn more.
 
 - The ``IndexView.DropOne()`` method returns only an error, if present. In
-  previous versions, this method returns the server response, which
-  contains the number of dropped indexes. See the
+  previous versions, this method also returned the server response, which
+  contained the number of dropped indexes. See the
   :ref:`golang-remove-index` section of the Indexes guide to learn more.
 
 .. _version-1.16:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-41551>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/golang/DOCSP-41551-dropone-return-type/fundamentals/indexes/#remove-an-index

[whats new
](https://preview-mongodbrustagir.gatsbyjs.io/golang/DOCSP-41551-dropone-return-type/whats-new/#what-s-new-in-2.0)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
