### PR TITLE
[v1.13] Merge pull request #426 from shuangela/DOCSP-46753-go-driver-count-docs-duplicate

### DIFF
--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -23,7 +23,7 @@ Usage Examples
    Write Operations </usage-examples/write-operations>
    Bulk Operations </usage-examples/bulkWrite>
    Monitor Data Changes </usage-examples/changestream>
-   Count Documents Usage Example </usage-examples/count>
+   Count Documents Method Example </usage-examples/count>
    Distinct Field Values </usage-examples/distinct>
    Run a Command </usage-examples/command>
    Use Struct Tags </usage-examples/struct-tagging>

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -23,7 +23,7 @@ Usage Examples
    Write Operations </usage-examples/write-operations>
    Bulk Operations </usage-examples/bulkWrite>
    Monitor Data Changes </usage-examples/changestream>
-   Count Documents </usage-examples/count>
+   Count Documents Usage Example </usage-examples/count>
    Distinct Field Values </usage-examples/distinct>
    Run a Command </usage-examples/command>
    Use Struct Tags </usage-examples/struct-tagging>

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -1,7 +1,7 @@
 .. _golang-count-usage-example:
 
 =============================
-Count Documents Usage Example
+Count Documents Method Example
 =============================
 
 .. default-domain:: mongodb

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -1,8 +1,8 @@
 .. _golang-count-usage-example:
 
-===============
-Count Documents
-===============
+=============================
+Count Documents Usage Example
+=============================
 
 .. default-domain:: mongodb
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.13`:
 - [Merge pull request #426 from shuangela/DOCSP-46753-go-driver-count-docs-duplicate](https://github.com/mongodb/docs-golang/pull/426)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)