### PR TITLE
[v1.12] Merge pull request #436 from shuangela/DOCSP-46755-insert-docs-go-change-title

### DIFF
--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -1,8 +1,8 @@
 .. _golang-insert-guide:
 
-=================
-Insert a Document
-=================
+================
+Insert Documents
+================
 
 .. facet::
    :name: genre

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -1,8 +1,8 @@
 .. _golang-insert-guide:
 
-================
-Insert Documents
-================
+=================
+Insert a Document
+=================
 
 .. facet::
    :name: genre

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -1,8 +1,8 @@
 .. _golang-insert-one:
 
-=================
-Insert a Document
-=================
+=========================
+Insert a Document Example
+=========================
 
 .. default-domain:: mongodb
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.12`:
 - [Merge pull request #436 from shuangela/DOCSP-46755-insert-docs-go-change-title](https://github.com/mongodb/docs-golang/pull/436)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)