### PR TITLE
[v2.0] Merge pull request #439 from shuangela/DOCSP-46761-write-operations-change-title

### DIFF
--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -20,7 +20,7 @@ Usage Examples
 .. toctree::
 
    Find Operations </usage-examples/find-operations>
-   Write Operation Examples </usage-examples/write-operations>
+   Write Operations </usage-examples/write-operations>
    Bulk Operations </usage-examples/bulkWrite>
    Monitor Data Changes </usage-examples/changestream>
    Count Documents Method Example </usage-examples/count>

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -20,7 +20,7 @@ Usage Examples
 .. toctree::
 
    Find Operations </usage-examples/find-operations>
-   Write Operations </usage-examples/write-operations>
+   Write Operation Examples </usage-examples/write-operations>
    Bulk Operations </usage-examples/bulkWrite>
    Monitor Data Changes </usage-examples/changestream>
    Count Documents Method Example </usage-examples/count>

--- a/source/usage-examples/write-operations.txt
+++ b/source/usage-examples/write-operations.txt
@@ -1,6 +1,6 @@
-================
-Write Operations
-================
+========================
+Write Operation Examples
+========================
 
 .. meta::
    :description: Learn by example: how to insert, update, and delete data by using the {+driver-long+}.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v2.0`:
 - [Merge pull request #439 from shuangela/DOCSP-46761-write-operations-change-title](https://github.com/mongodb/docs-golang/pull/439)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)