### PR TITLE
DOCSP-49300 Add noindex to legacy v1.11

### DIFF
--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-compatibility:
 
 =============

--- a/source/connection-troubleshooting.txt
+++ b/source/connection-troubleshooting.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-connection-troubleshooting:
 
 ==========================

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-faq:
 
 ===

--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ============
 Fundamentals
 ============

--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-aggregation:
 
 ===========

--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-authentication-mechanisms:
 
 =========================

--- a/source/fundamentals/bson.txt
+++ b/source/fundamentals/bson.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-bson:
 
 ==============

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-collations:
 
 ==========

--- a/source/fundamentals/connections.txt
+++ b/source/fundamentals/connections.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-connection:
 
 ===========

--- a/source/fundamentals/connections/connection-guide.txt
+++ b/source/fundamentals/connections/connection-guide.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-connection-guide:
 
 ================

--- a/source/fundamentals/connections/network-compression.txt
+++ b/source/fundamentals/connections/network-compression.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-network-compression:
 
 ===================

--- a/source/fundamentals/connections/tls.txt
+++ b/source/fundamentals/connections/tls.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-tls:
 
 ========================

--- a/source/fundamentals/context.txt
+++ b/source/fundamentals/context.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-context:
 
 =======

--- a/source/fundamentals/crud.txt
+++ b/source/fundamentals/crud.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-crud:
 
 ===============

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-compound-operations:
 
 ===================

--- a/source/fundamentals/crud/read-operations.txt
+++ b/source/fundamentals/crud/read-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-crud-read-operations:
 
 ===============

--- a/source/fundamentals/crud/read-operations/changestream.txt
+++ b/source/fundamentals/crud/read-operations/changestream.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-watch-changes:
 .. _golang-monitor-changes:
 

--- a/source/fundamentals/crud/read-operations/count.txt
+++ b/source/fundamentals/crud/read-operations/count.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-count-documents:
 
 ===============

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-cursor:
 
 =========================

--- a/source/fundamentals/crud/read-operations/distinct.txt
+++ b/source/fundamentals/crud/read-operations/distinct.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-retrieve-distinct:
 
 ========================

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-limit:
 
 ====================================

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-project:
 
 ==============================

--- a/source/fundamentals/crud/read-operations/query-document.txt
+++ b/source/fundamentals/crud/read-operations/query-document.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-query-document:
 
 ===============

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-retrieve:
 
 ==============

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-skip:
 
 =====================

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-sort-results:
 
 ============

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-search-text:
 
 ===========

--- a/source/fundamentals/crud/write-operations.txt
+++ b/source/fundamentals/crud/write-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-crud-write-operations:
 
 ================

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-bulk:
 
 ===============

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-delete-guide:
 
 ================

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-update-arrays:
 
 ===========================

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-insert-guide:
 
 =================

--- a/source/fundamentals/crud/write-operations/modify.txt
+++ b/source/fundamentals/crud/write-operations/modify.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-change-document:
 
 ================

--- a/source/fundamentals/crud/write-operations/upsert.txt
+++ b/source/fundamentals/crud/write-operations/upsert.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-upsert-guide:
 
 ======================================

--- a/source/fundamentals/crud/write-read-pref.txt
+++ b/source/fundamentals/crud/write-read-pref.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-write-read-pref:
 
 ===================================

--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-fle:
 
 .. sharedinclude:: dbx/encrypt-fields.rst

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-enterprise-authentication-mechanisms:
 
 ====================================

--- a/source/fundamentals/geo.txt
+++ b/source/fundamentals/geo.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-geo:
 
 =========================

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-gridfs:
 
 ======

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-indexes:
 
 =======

--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-monitoring:
 
 ==========

--- a/source/fundamentals/monitoring/cluster-monitoring.txt
+++ b/source/fundamentals/monitoring/cluster-monitoring.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-cluster-monitoring:
 
 ==================

--- a/source/fundamentals/monitoring/command-monitoring.txt
+++ b/source/fundamentals/monitoring/command-monitoring.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-command-monitoring:
 
 ==================

--- a/source/fundamentals/monitoring/connection-monitoring.txt
+++ b/source/fundamentals/monitoring/connection-monitoring.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-connection-monitoring:
 
 =====================

--- a/source/fundamentals/run-command.txt
+++ b/source/fundamentals/run-command.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-run-command:
 
 =============

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-stable-api:
 
 ==============

--- a/source/fundamentals/time-series.txt
+++ b/source/fundamentals/time-series.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-time-series:
 
 =======================

--- a/source/fundamentals/transactions.txt
+++ b/source/fundamentals/transactions.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-transactions:
 
 ============

--- a/source/index.txt
+++ b/source/index.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 =================
 {+driver-long+}
 =================

--- a/source/issues-and-help.txt
+++ b/source/issues-and-help.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-issues-and-help:
 
 =============

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-quick-reference:
 
 ===============

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-quickstart:
 
 =====================

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-usage-examples:
 
 ==============

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-bulk-ops-usage-example:
 
 =======================

--- a/source/usage-examples/changestream.txt
+++ b/source/usage-examples/changestream.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-watch:
 .. _golang-usageex-monitor-changes:
 

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-run-command-usage-example:
 
 =============

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-count-usage-example:
 
 ===============

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-delete-many:
 
 =========================

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-delete-one:
 
 =================

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-distinct-usage-example:
 
 ===================================

--- a/source/usage-examples/find-operations.txt
+++ b/source/usage-examples/find-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ===============
 Find Operations
 ===============

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-find-multiple:
 
 =======================

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-find-one:
 
 ===============

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-insert-many:
 
 =========================

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-insert-one:
 
 =================

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-replace:
 
 ==================

--- a/source/usage-examples/struct-tagging.txt
+++ b/source/usage-examples/struct-tagging.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-struct-tags-usage-example:
 
 ===============

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-update-many:
 
 =========================

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-update-one:
 
 =================

--- a/source/usage-examples/write-operations.txt
+++ b/source/usage-examples/write-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ================
 Write Operations
 ================

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _golang-whats-new:
 
 ==========


### PR DESCRIPTION
# Pull Request Info

Add `noindex` by using the EOL bash script.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-v1.11>


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
