### PR TITLE
DOCSP-49699: compound ops page typo fix

### DIFF
--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -89,11 +89,11 @@ Modify Behavior
 ~~~~~~~~~~~~~~~
 
 You can modify the behavior of the ``FindOneAndDelete()`` method by
-passing in a ``FineOneAndDeleteOptions``. If you don't specify a
-``FineOneAndDeleteOptions``, the driver uses the default values for each
+passing in a ``FindOneAndDeleteOptions``. If you don't specify a
+``FindOneAndDeleteOptions``, the driver uses the default values for each
 option.
 
-The ``FineOneAndDeleteOptions`` type allows you to configure options
+The ``FindOneAndDeleteOptions`` type allows you to configure options
 with the following methods:
 
 .. list-table::
@@ -174,11 +174,11 @@ Modify Behavior
 ~~~~~~~~~~~~~~~
 
 You can modify the behavior of the ``FindOneAndUpdate()`` method by
-passing in a ``FineOneAndUpdateOptions``. If you don't specify a
-``FineOneAndUpdateOptions``, the driver uses the default values for each
+passing in a ``FindOneAndUpdateOptions``. If you don't specify a
+``FindOneAndUpdateOptions``, the driver uses the default values for each
 option.
 
-The ``FineOneAndUpdateOptions`` type allows you to configure options
+The ``FindOneAndUpdateOptions`` type allows you to configure options
 with the following methods:
 
 .. list-table::
@@ -276,11 +276,11 @@ Modify Behavior
 ~~~~~~~~~~~~~~~
 
 You can modify the behavior of the ``FindOneAndReplace()`` method by
-passing in a ``FineOneAndReplaceOptions``. If you don't specify a
-``FineOneAndReplaceOptions``, the driver uses the default values for each
+passing in a ``FindOneAndReplaceOptions``. If you don't specify a
+``FindOneAndReplaceOptions``, the driver uses the default values for each
 option.
 
-The ``FineOneAndReplaceOptions`` type allows you to configure options
+The ``FindOneAndReplaceOptions`` type allows you to configure options
 with the following methods:
 
 .. list-table::

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -7,8 +7,6 @@ Compound Operations
 .. meta::
    :description: Learn how to perform compound operations in MongoDB using Go, combining read and write actions into a single atomic operation to prevent data alteration.
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -78,12 +76,12 @@ the specified query filter and deletes it. The method returns a
 
    The ``FindOneAndDelete()`` method is an atomic operation, which means it prevents
    any other write operations from changing the matching document until it
-   completes. The ``deleteOne()`` method is also an atomic operation, but differs from
+   completes. The ``DeleteOne()`` method is also an atomic operation, but differs from
    ``FindOneAndDelete()`` in that you cannot specify a sort order for the
    matched documents. 
 
    To find a document and delete it in separate operations, call the
-	 ``findOne()`` method followed by the ``deleteOne()`` method.
+   ``FindOne()`` method followed by the ``DeleteOne()`` method.
 
 Modify Behavior
 ~~~~~~~~~~~~~~~
@@ -163,12 +161,12 @@ document.
 
    The ``FindOneAndUpdate()`` method is an atomic operation, which means it prevents
    any other write operations from changing the matching document until it
-   completes. The ``updateOne()`` method is also an atomic operation, but differs from
-   ``FindOneAndUpdate()`` in that you cannot specify a sort order for the
-   matched documents. 
+   completes. The ``UpdateOne()`` method is also an atomic operation, but differs from
+   ``FindOneAndUpdate()`` because you cannot return the pre-image of the
+   updated document when using ``UpdateOne()``.
 
    To find a document and update it in separate operations, call 
-   the ``findOne()`` method followed by the ``updateOne()`` method. 
+   the ``FindOne()`` method followed by the ``UpdateOne()`` method. 
  
 Modify Behavior
 ~~~~~~~~~~~~~~~

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -7,8 +7,6 @@ Skip Returned Results
 .. meta::
    :description: Learn how to skip a specified number of results in MongoDB read operations using the setSkip() method or the $skip stage in aggregation pipelines.
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -7,8 +7,6 @@ Sort Results
 .. meta::
    :description: Learn how to sort query results, handle ties, and apply sorting in aggregation pipelines with the MongoDB Go Driver.
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -7,8 +7,6 @@ Bulk Operations
 .. meta::
    :description: Learn to perform bulk write operations with the MongoDB Go Driver, including inserts, updates, replacements, and deletions, using the bulkWrite() method.
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -789,4 +787,5 @@ see the following API documentation:
 - `NewClientUpdateOneModel() <{+api+}/mongo#NewClientUpdateOneModel>`__
 - `NewClientUpdateManyModel() <{+api+}/mongo#NewClientUpdateManyModel>`__
 - `NewClientDeleteOneModel() <{+api+}/mongo#NewClientDeleteOneModel>`__
-- `NewClientDeleteManyModel() <{+api+}/mongo#NewClientDeleteManyModel>`__
+- `NewClientDeleteManyModel()
+  <{+api+}/mongo#NewClientDeleteManyModel>`__

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -5,7 +5,7 @@ Delete Documents
 ================
 
 .. meta::
-   :description: Learn how to remove documents from collections with the deleteOne() and deleteMany() methods in the MongoDB Go Driver, with examples and options.
+   :description: Learn how to remove documents from collections with the DeleteOne() and DeleteMany() methods in the MongoDB Go Driver, with examples and options.
 
 .. contents:: On this page
    :local:

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -10,7 +10,7 @@ Insert a Document
 
 .. meta::
    :keywords: code example, write operation, add data
-   :description: Learn how to insert documents into a MongoDB collection using the insertOne() and insertMany() methods, with options to modify their behavior.
+   :description: Learn how to insert documents into a MongoDB collection using the InsertOne() and InsertMany() methods, with options to modify their behavior.
 
 .. contents:: On this page
    :local:

--- a/source/fundamentals/crud/write-operations/modify.txt
+++ b/source/fundamentals/crud/write-operations/modify.txt
@@ -10,7 +10,7 @@ Modify Documents
 
 .. meta::
    :keywords: code example, write operation, change data
-   :description: Learn how to modify MongoDB documents using update and replace operations, including methods like updateOne(), updateMany(), and replaceOne().
+   :description: Learn how to modify MongoDB documents using update and replace operations, including methods like UpdateOne(), UpdateMany(), and ReplaceOne().
    
 .. contents:: On this page
    :local:

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -86,8 +86,8 @@ results directly from the index, also called a **covered query**.
    - ``name`` ascending, ``age`` descending
    - ``name`` descending, ``age`` ascending
 
-   Specifying a sort order of ``name`` and :guilabel:`age` ascending or :guilabel:`name` and ``age``
-   descending requires an in-memory sort.
+   However, specifying a sort order of both fields in the same
+   direction requires an in-memory sort.
 
    To learn how to ensure your index covers your query criteria and
    projection, see :manual:`Query Coverage

--- a/source/fundamentals/stable-api.txt
+++ b/source/fundamentals/stable-api.txt
@@ -7,8 +7,6 @@
 .. meta::
    :description: Learn how to specify Stable API compatibility in the MongoDB Go Driver to ensure operations align with a defined API version.
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/quick-reference.txt
+++ b/source/quick-reference.txt
@@ -7,8 +7,6 @@ Quick Reference
 .. meta::
    :description: Explore with the MongoDB Go Driver syntax for various commands, including find, insert, update, delete, and more, with links to API documentation and usage examples.
 
-.. default-domain:: mongodb
-
 This page shows the driver syntax for several MongoDB commands and links to
 their related reference and API documentation.
 

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -7,8 +7,6 @@ Run a Command Example
 .. meta::
    :description: Learn how to execute commands on a MongoDB server using the runCommand() method in Go, with an example retrieving database statistics.
 
-.. default-domain:: mongodb
-
 You can run commands directly on your MongoDB server by using the
 ``RunCommand()`` method.
 

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -5,9 +5,7 @@ Delete Multiple Documents
 =========================
 
 .. meta::
-   :description: Learn how to delete multiple documents from a collection using the deleteMany() method in the MongoDB Go Driver.
-
-.. default-domain:: mongodb
+   :description: Learn how to delete multiple documents from a collection using the DeleteMany() method in the MongoDB Go Driver.
 
 You can delete multiple documents in a collection by using the
 ``DeleteMany()`` method.

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -5,7 +5,7 @@ Delete a Document
 =================
 
 .. meta::
-   :description: Learn how to delete a document from a collection using the deleteOne() method in the MongoDB Go Driver.
+   :description: Learn how to delete a document from a collection using the DeleteOne() method in the MongoDB Go Driver.
 
 You can delete a document in a collection by using the ``DeleteOne()``
 method.

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -5,9 +5,7 @@ Find a Document
 ===============
 
 .. meta::
-   :description: Retrieve a single document from a collection using the findOne() method in the MongoDB Go Driver.
-
-.. default-domain:: mongodb
+   :description: Retrieve a single document from a collection using the FindOne() method in the MongoDB Go Driver.
 
 You can retrieve a single document from a collection by using the
 ``FindOne()`` method.

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -5,9 +5,7 @@ Insert Multiple Documents
 =========================
 
 .. meta::
-   :description: Learn how to insert multiple documents into a collection using the insertMany() method in the MongoDB Go Driver.
-
-.. default-domain:: mongodb
+   :description: Learn how to insert multiple documents into a collection using the InsertMany() method in the MongoDB Go Driver.
 
 You can insert multiple documents into a collection by using the ``InsertMany()``
 method.

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -5,9 +5,7 @@ Insert a Document Example
 =========================
 
 .. meta::
-   :description: Learn how to insert a document into a collection using the insertOne() method in the MongoDB Go Driver.
-
-.. default-domain:: mongodb
+   :description: Learn how to insert a document into a collection using the InsertOne() method in the MongoDB Go Driver.
 
 You can insert a document into a collection by using the ``InsertOne()``
 method.

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -5,9 +5,7 @@ Replace a Document
 ==================
 
 .. meta::
-   :description: Learn how to replace a document in a MongoDB collection using the replaceOne() method with the MongoDB Go Driver.
-
-.. default-domain:: mongodb
+   :description: Learn how to replace a document in a MongoDB collection using the ReplaceOne() method with the MongoDB Go Driver.
 
 You can replace a document in a collection by using the ``ReplaceOne()``
 method.

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -5,7 +5,7 @@ Update Multiple Documents
 =========================
 
 .. meta::
-   :description: Learn how to update multiple documents in a collection using the updateMany() method in the MongoDB Go Driver.
+   :description: Learn how to update multiple documents in a collection using the UpdateMany() method in the MongoDB Go Driver.
 
 You can update multiple documents in a collection by using the ``UpdateMany()``
 method.

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -5,7 +5,7 @@ Update a Document
 =================
 
 .. meta::
-   :description: Learn how to update a document in a collection using the updateOne() method in the MongoDB Go Driver.
+   :description: Learn how to update a document in a collection using the UpdateOne() method in the MongoDB Go Driver.
 
 You can update a document in a collection by using the ``UpdateOne()``
 method.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -86,12 +86,12 @@ What's New in 2.1
 The 2.1 {+driver-short+} release includes the following improvements
 and fixes:
 
-- Introduces the new `Client.BulkWrite <{+api+}/mongo#Client.BulkWrite>`__ method, 
+- Introduces the `Client.BulkWrite <{+api+}/mongo#Client.BulkWrite>`__ method, 
   enabling clients to perform multiple insert, update, and delete operations across 
   multiple databases and collections in a single request. To learn more, see the
   :ref:`golang-bulk` guide.
 
-- Introduces the new `bson.Vector <{+api+}/bson#Vector>`__ type to make inserting and querying 
+- Introduces the `bson.Vector <{+api+}/bson#Vector>`__ type to make inserting and querying 
   vector data by using :atlas:`Atlas Vector Search </atlas-vector-search/vector-search-overview/>` 
   easier and more efficient. For an example using the ``bson.Vector`` type, see
   the {+driver-short+}'s :ref:`Atlas Vector Search <golang-atlas-vector-search>` guide. 
@@ -101,8 +101,9 @@ and fixes:
   the server during the lifetime of operation execution.
 
 - Adds the ``sort`` option to `UpdateOneOptions <{+api+}/mongo/options#UpdateOneOptions>`__ 
-  and `ReplaceOptions <{+api+}/mongo/options#ReplaceOptions>`__ for the ``updateOne`` 
-  and ``replaceOne`` operations. 
+  and `ReplaceOptions <{+api+}/mongo/options#ReplaceOptions>`__ for
+  ``UpdateOne()`` and ``ReplaceOne()`` operations and update and replace
+  operations in bulk operations.
 
 For more information about the changes in this version, see the
 :github:`v2.1 release notes </mongodb/mongo-go-driver/releases/tag/v2.1.0>` 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -102,7 +102,7 @@ and fixes:
 
 - Adds the ``sort`` option to `UpdateOneOptions <{+api+}/mongo/options#UpdateOneOptions>`__ 
   and `ReplaceOptions <{+api+}/mongo/options#ReplaceOptions>`__ for
-  standalone update and replace operations as well as for bulk operations.
+  standalone update and replace operations and in bulk operations.
 
 For more information about the changes in this version, see the
 :github:`v2.1 release notes </mongodb/mongo-go-driver/releases/tag/v2.1.0>` 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -93,8 +93,8 @@ and fixes:
 
 - Introduces the `bson.Vector <{+api+}/bson#Vector>`__ type to make inserting and querying 
   vector data by using :atlas:`Atlas Vector Search </atlas-vector-search/vector-search-overview/>` 
-  easier and more efficient. For an example using the ``bson.Vector`` type, see
-  the {+driver-short+}'s :ref:`Atlas Vector Search <golang-atlas-vector-search>` guide. 
+  easier and more efficient. To view an example that uses the ``bson.Vector`` type, see
+  the :ref:`Atlas Vector Search <golang-atlas-vector-search>` guide. 
 
 - Extends the `ServerError <{+api+}/mongo#ServerError>`__ interface to include 
   ``ErrorCodes``, which returns a list of deduplicated error codes returned by 
@@ -102,8 +102,7 @@ and fixes:
 
 - Adds the ``sort`` option to `UpdateOneOptions <{+api+}/mongo/options#UpdateOneOptions>`__ 
   and `ReplaceOptions <{+api+}/mongo/options#ReplaceOptions>`__ for
-  ``UpdateOne()`` and ``ReplaceOne()`` operations and update and replace
-  operations in bulk operations.
+  standalone update and replace operations as well as for bulk operations.
 
 For more information about the changes in this version, see the
 :github:`v2.1 release notes </mongodb/mongo-go-driver/releases/tag/v2.1.0>` 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-49699>
Staging - https://deploy-preview-496--docs-golang.netlify.app/fundamentals/crud/compound-operations/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
